### PR TITLE
Switch to non-abandoned kubectl provider

### DIFF
--- a/cluster/terraform/versions.tf
+++ b/cluster/terraform/versions.tf
@@ -15,8 +15,8 @@ terraform {
       version = ">= 2.4.1"
     }
     kubectl = {
-      source  = "gavinbunney/kubectl"
-      version = ">= 1.14"
+      source  = "alekc/kubectl"
+      version = ">= 2.0.2"
     }
     docker = {
       source  = "kreuzwerker/docker"


### PR DESCRIPTION
### Fixes error message "the server could not find the requested resource" on EKS/Kubernetes 1.27 for kubectl_manifest resources

Both resources "kubectl_manifest.karpenter_default_ec2_node_class" and "kubectl_manifest.karpenter_default_node_pool"  can not created properly by terraform. This leads to an unfinished state while using this blueprints. 

Used EKS version: 1.27

Regardless of whether the k8s resources already exist or not, this error occurs, see here:

```
terraform apply -target="kubectl_manifest.karpenter_default_ec2_node_class"

kubectl_manifest.karpenter_default_ec2_node_class: Creating...
kubectl_manifest.karpenter_default_ec2_node_class: Still creating... [10s elapsed]
kubectl_manifest.karpenter_default_ec2_node_class: Still creating... [20s elapsed]
kubectl_manifest.karpenter_default_ec2_node_class: Still creating... [30s elapsed]
kubectl_manifest.karpenter_default_ec2_node_class: Still creating... [40s elapsed]
kubectl_manifest.karpenter_default_ec2_node_class: Still creating... [50s elapsed]
kubectl_manifest.karpenter_default_ec2_node_class: Still creating... [1m0s elapsed]
kubectl_manifest.karpenter_default_ec2_node_class: Still creating... [1m10s elapsed]
kubectl_manifest.karpenter_default_ec2_node_class: Still creating... [1m20s elapsed]
kubectl_manifest.karpenter_default_ec2_node_class: Still creating... [1m30s elapsed]
kubectl_manifest.karpenter_default_ec2_node_class: Still creating... [1m40s elapsed]
kubectl_manifest.karpenter_default_ec2_node_class: Still creating... [1m50s elapsed]
kubectl_manifest.karpenter_default_ec2_node_class: Still creating... [2m0s elapsed]
kubectl_manifest.karpenter_default_ec2_node_class: Still creating... [2m10s elapsed]
kubectl_manifest.karpenter_default_ec2_node_class: Still creating... [2m20s elapsed]
...
╷
│ Error: default failed to fetch resource from kubernetes: the server could not find the requested resource
│ 
│   with kubectl_manifest.karpenter_default_ec2_node_class,
│   on karpenter.tf line 3, in resource "kubectl_manifest" "karpenter_default_ec2_node_class":
│    3: resource "kubectl_manifest" "karpenter_default_ec2_node_class" {
│ 
```

The used provider of user gavinbunny seems abandoned, see here: 
https://github.com/gavinbunney/terraform-provider-kubectl/issues/270

Therefore I would propose to switch to alekc/kubectl which also fixes the mentioned bug while using kubectl_manifest resource creation. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
