### PR TITLE
cluster version and modules updated

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,9 +150,6 @@ The following table describes the list of resources along with the versions wher
 | [AWS EKS](https://github.com/terraform-aws-modules/terraform-aws-eks/releases)  | 20.8.3               |
 | [EKS Blueprints Addons](https://github.com/aws-ia/terraform-aws-eks-blueprints-addons/releases)  | 1.16.10               |
 
-
-1.16.1"
-
 ## Feedback
 
 To post feedback, submit a new blueprint, or report bugs, please use the [Issues section](https://github.com/aws-samples/karpenter-blueprints/issues) of this GitHub repo. 

--- a/README.md
+++ b/README.md
@@ -147,7 +147,11 @@ The following table describes the list of resources along with the versions wher
 | [Kubernetes](https://kubernetes.io/releases/)      | 1.29                |
 | [Karpenter](https://github.com/aws/karpenter/releases)       | 0.35             |
 | [Terraform](https://github.com/hashicorp/terraform/releases)       | 1.6.3             |
-| [EKS Blueprints](https://github.com/aws-ia/terraform-aws-eks-blueprints-addons/releases)  | 1.16.10               |
+| [AWS EKS](https://github.com/terraform-aws-modules/terraform-aws-eks/releases)  | 20.8.3               |
+| [EKS Blueprints Addons](https://github.com/aws-ia/terraform-aws-eks-blueprints-addons/releases)  | 1.16.10               |
+
+
+1.16.1"
 
 ## Feedback
 

--- a/README.md
+++ b/README.md
@@ -144,10 +144,10 @@ The following table describes the list of resources along with the versions wher
 
 | Resources/Tool  | Version             |
 | --------------- | ------------------- |
-| [Kubernetes](https://kubernetes.io/releases/)      | 1.28                |
-| [Karpenter](https://github.com/aws/karpenter/releases)       | 0.32.1             |
+| [Kubernetes](https://kubernetes.io/releases/)      | 1.29                |
+| [Karpenter](https://github.com/aws/karpenter/releases)       | 0.35             |
 | [Terraform](https://github.com/hashicorp/terraform/releases)       | 1.6.3             |
-| [EKS Blueprints](https://github.com/aws-ia/terraform-aws-eks-blueprints-addons/releases)  | 1.12.0               |
+| [EKS Blueprints](https://github.com/aws-ia/terraform-aws-eks-blueprints-addons/releases)  | 1.16.10               |
 
 ## Feedback
 

--- a/blueprints/custom-ami/custom-ami.yaml
+++ b/blueprints/custom-ami/custom-ami.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   amiFamily: AL2
   amiSelectorTerms:
-  - name: '*amazon-eks-node-1.27-*'
+  - name: '*amazon-eks-node-1.29-*'
   role: "<<KARPENTER_NODE_IAM_ROLE_NAME>>"
   securityGroupSelectorTerms:
   - tags:


### PR DESCRIPTION
**Description:**

This PR includes updates to the Terraform configuration for managing the AWS EKS cluster and related components.

**Changes:**

1. **Cluster Version Update:**
   - Updated `cluster_version` from `"1.28"` to `"1.29"`.

2. **Module "eks" Updates:**
   - Upgraded Terraform AWS EKS module to version `"20.8.3"`.
   - Added `authentication_mode` and `enable_cluster_creator_admin_permissions` attributes.
 
3. **Update EBS CSI Driver**
   - Updated  to version "5.37.1"

4.  **aws-auth module**
   - Removal of aws-auth from aws-eks module. Inline with blueprints.
   - Now using "terraform-aws-modules/eks/aws//modules/aws-auth"


**Impact:**

- Upgrades EKS cluster to version `"1.29"`.
- Cluster Authentication via API and config map
- Updates Terraform AWS EKS module to version `"20.8.3"`.
- Upgrade the `ebs_csi_driver_irsa` module to version "5.37.1".
- "aws-auth" now handled by separate module