### PR TITLE
Modify blueprint od-spot-split by removing on-demand as capacity type in NodePool node-spot

### DIFF
--- a/blueprints/od-spot-split/od-spot.yaml
+++ b/blueprints/od-spot-split/od-spot.yaml
@@ -82,7 +82,6 @@ spec:
         operator: In
         values:
         - spot
-        - on-demand
       - key: kubernetes.io/os
         operator: In
         values:


### PR DESCRIPTION
*Issue #, if available:*
[Blueprint od-spot-split contains spot and on-demand as capacity type in NodePool node-spot which might be misleading #11](https://github.com/aws-samples/karpenter-blueprints/issues/11)
*Description of changes:*
Remove `on-demand` from `karpenter.sh/capacity-type` section for NodePool `node-spot`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
