### PR TITLE
filter local zones

### DIFF
--- a/cluster/terraform/main.tf
+++ b/cluster/terraform/main.tf
@@ -38,7 +38,12 @@ data "aws_ecrpublic_authorization_token" "token" {
   provider = aws.virginia
 }
 
-data "aws_availability_zones" "available" {}
+data "aws_availability_zones" "available" {
+  filter {
+    name   = "opt-in-status"
+    values = ["opt-in-not-required"]
+  }
+}
 
 locals {
   name            = "karpenter-blueprints"


### PR DESCRIPTION
default cluster creation doesn't internally distinguish local zones

tf may try to create a nat gateway there or the control plane both will result in a failed create status

*Issue #, if available:*

*Description of changes:*
added a filter to availability zones to exclude local zones for the default deployment topology

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
