### PR TITLE
V1 Release

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,11 @@
 ## Motivation
 [Karpenter](https://karpenter.sh/), a node provisioning project built for Kubernetes has been helping many companies to improve the efficiency and cost of running workloads on Kubernetes. However, as Karpenter takes an application-first approach to provision compute capacity for the Kubernetes data plane, there are common workload scenarios that you might be wondering how to configure them properly. This repository includes a list of common workload scenarios, some of them go in depth with the explanation of why configuring Karpenter and Kubernetes objects in such a way is important.
 
+#### V1 Release
+
+> In the [v1 release](https://aws.amazon.com/blogs/containers/announcing-karpenter-1-0/), the custom resource definition (CRD) API groups and kind names remain unchanged. Conversion webhooks are now available to facilitate a seamless migration from beta to stable. Support for `v1beta1` APIs will be deprecated in the next minor release (v1.1.0).
+
+
 ## Blueprint Structure
 Each blueprint follows the same structure to help you better understand what's the motivation and the expected results:
 
@@ -90,7 +95,7 @@ You can see that the NodePool has been deployed by running this:
 kubectl get nodepool
 ```
 
-You can see that the EC2NodeClass has been deployed by running this:
+You can see that the `EC2NodeClass` has been deployed by running this:
 
 ```
 kubectl get ec2nodeclass
@@ -120,7 +125,7 @@ terraform destroy --auto-approve
 
 ## Deploying a Blueprint
 
-After you have a cluster up and running with Karpenter installed, you can start testing each blueprint. A blueprint might have a NodePool, EC2NodeClass and a workload example. You need to open the blueprint folder and follow the steps to deploy the resources needed to test the blueprint.
+After you have a cluster up and running with Karpenter installed, you can start testing each blueprint. A blueprint might have a `NodePool`, `EC2NodeClass` and a workload example. You need to open the blueprint folder and follow the steps to deploy the resources needed to test the blueprint.
 
 Here's the list of blueprints we have so far:
 
@@ -146,10 +151,10 @@ The following table describes the list of resources along with the versions wher
 | Resources/Tool  | Version             |
 | --------------- | ------------------- |
 | [Kubernetes](https://kubernetes.io/releases/)      | 1.30                |
-| [Karpenter](https://github.com/aws/karpenter/releases)       | 0.37             |
-| [Terraform](https://github.com/hashicorp/terraform/releases)       | 1.6.3             |
-| [AWS EKS](https://github.com/terraform-aws-modules/terraform-aws-eks/releases)  | 20.8.3               |
-| [EKS Blueprints Addons](https://github.com/aws-ia/terraform-aws-eks-blueprints-addons/releases)  | 1.16.10               |
+| [Karpenter](https://github.com/aws/karpenter/releases)       | v1.9.4             |
+| [Terraform](https://github.com/hashicorp/terraform/releases)       | 1.9.3            |
+| [AWS EKS](https://github.com/terraform-aws-modules/terraform-aws-eks/releases)  | v20.23.0             |
+| [EKS Blueprints Addons](https://github.com/aws-ia/terraform-aws-eks-blueprints-addons/releases)  | v1.16.3              |
 
 ## Feedback
 

--- a/README.md
+++ b/README.md
@@ -3,11 +3,6 @@
 ## Motivation
 [Karpenter](https://karpenter.sh/), a node provisioning project built for Kubernetes has been helping many companies to improve the efficiency and cost of running workloads on Kubernetes. However, as Karpenter takes an application-first approach to provision compute capacity for the Kubernetes data plane, there are common workload scenarios that you might be wondering how to configure them properly. This repository includes a list of common workload scenarios, some of them go in depth with the explanation of why configuring Karpenter and Kubernetes objects in such a way is important.
 
-#### V1 Release
-
-> In the [v1 release](https://aws.amazon.com/blogs/containers/announcing-karpenter-1-0/), the custom resource definition (CRD) API groups and kind names remain unchanged. Conversion webhooks are now available to facilitate a seamless migration from beta to stable. Support for `v1beta1` APIs will be deprecated in the next minor release (v1.1.0).
-
-
 ## Blueprint Structure
 Each blueprint follows the same structure to help you better understand what's the motivation and the expected results:
 
@@ -151,7 +146,7 @@ The following table describes the list of resources along with the versions wher
 | Resources/Tool  | Version             |
 | --------------- | ------------------- |
 | [Kubernetes](https://kubernetes.io/releases/)      | 1.30                |
-| [Karpenter](https://github.com/aws/karpenter/releases)       | v1.9.4             |
+| [Karpenter](https://github.com/aws/karpenter/releases)       | v1.0.0            |
 | [Terraform](https://github.com/hashicorp/terraform/releases)       | 1.9.3            |
 | [AWS EKS](https://github.com/terraform-aws-modules/terraform-aws-eks/releases)  | v20.23.0             |
 | [EKS Blueprints Addons](https://github.com/aws-ia/terraform-aws-eks-blueprints-addons/releases)  | v1.16.3              |

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ The following table describes the list of resources along with the versions wher
 | Resources/Tool  | Version             |
 | --------------- | ------------------- |
 | [Kubernetes](https://kubernetes.io/releases/)      | 1.30                |
-| [Karpenter](https://github.com/aws/karpenter/releases)       | v1.0.0            |
+| [Karpenter](https://github.com/aws/karpenter/releases)       | v1.0.1            |
 | [Terraform](https://github.com/hashicorp/terraform/releases)       | 1.9.3            |
 | [AWS EKS](https://github.com/terraform-aws-modules/terraform-aws-eks/releases)  | v20.23.0             |
 | [EKS Blueprints Addons](https://github.com/aws-ia/terraform-aws-eks-blueprints-addons/releases)  | v1.16.3              |

--- a/blueprints/batch-jobs/README.md
+++ b/blueprints/batch-jobs/README.md
@@ -172,7 +172,9 @@ Now, the total number of vCPU required by the running pods are **4 vCPU**:
 ```
 $> kubectl describe node <node_name>
 ...
-  Normal    DisruptionBlocked   36s karpenter   Cannot disrupt Node: pod "default/2-min-job-czp5x" has "karpenter.sh/do-not-disrupt" annotation
+  Normal   NodeReady                6m7s                   kubelet                Node ip-10-0-97-15.eu-west-1.compute.internal status is now: NodeReady
+  Normal   DisruptionBlocked        4m12s                  karpenter              Cannot disrupt Node: pod "default/2-min-job-2fssd" has "karpenter.sh/do-not-disrupt" annotation
+  Normal   DisruptionBlocked        2m12s                  karpenter              Cannot disrupt Node: pod "default/5-min-job-7pqdt" has "karpenter.sh/do-not-disrupt" annotation
 ```
 
 ### Consolidation Replace allowed after last job finishes

--- a/blueprints/batch-jobs/README.md
+++ b/blueprints/batch-jobs/README.md
@@ -1,4 +1,4 @@
-# Karpenter Blueprint: Protecting batch jobs during the consolidation process
+# Karpenter Blueprint: Protecting batch jobs during the disruption (consolidation) process
 
 ## Purpose
 Karpenter can actively reduce the cluster cost by identifying when nodes can be removed or replaced because they are empty or there are a cheaper one available after some workload change. This process is called [consolidation](https://karpenter.sh/preview/concepts/disruption/#consolidation), and it implies the disruption of pods that are running in the node, if any, as they need to be rescheduled into another node. In some cases, like when running long batch jobs, you don't want those pods to be disrupted. You want to run them from start to finish without disruption, and replace or delete the node once they finish. To achieve that, you can set the `karpenter.sh/do-not-disrupt: "true"` annotation on the pod (more information [here](https://karpenter.sh/preview/concepts/disruption/#pod-level-controls)). By opting pods out of this disruption, you are telling Karpenter that it should not voluntarily remove a node containing this pod.
@@ -50,15 +50,15 @@ Now, the total number of vCPU required by the running pods are **4 vCPU**:
 - NGINX server - 2 vCPU required
 -  5-minutes job - 2 vCPU required 
 
-The default behaviour is the one defined in the NodePool: `consolidationPolicy: WhenUnderutilized`. Karpenter identifies the **c6g.4xlarge** (12 vCPU) is underutilized, and performs a consolidation replacement of the node. It launches a cheaper and smaller node: a **c6g.2xlarge** (8 vCPU) instance. You can check these logs by executing the following command in another terminal:
+The default behaviour is the one defined in the NodePool: `consolidationPolicy: WhenEmptyOrUnderutilized`. Karpenter identifies the **c6g.4xlarge** (12 vCPU) is underutilized, and performs a consolidation replacement of the node. It launches a cheaper and smaller node: a **c6g.2xlarge** (8 vCPU) instance. You can check these logs by executing the following command in another terminal:
 ```
 kubectl -n karpenter logs -l app.kubernetes.io/name=karpenter --all-containers=true -f --tail=20
 ```
 You should see these logs:
 ```
-{"level":"INFO","time":"2024-01-10T15:06:37.063Z","logger":"controller.disruption","message":"disrupting via consolidation replace, terminating 1 candidates ip-10-0-93-19.eu-west-1.compute.internal/c6g.4xlarge/on-demand and replacing with on-demand node from types r6gd.2xlarge, c7i.2xlarge, r5a.2xlarge, m5a.2xlarge, m6a.2xlarge and 37 other(s)","commit":"1072d3b"}
+{"level":"INFO","time":"2024-08-16T10:03:46.529Z","logger":"controller","message":"disrupting nodeclaim(s) via replace, terminating 1 nodes (2 pods) ip-10-0-122-231.eu-west-2.compute.internal/c6g.4xlarge/on-demand and replacing with on-demand node from types c6g.2xlarge, c7g.2xlarge, m6g.2xlarge, c6a.2xlarge, c5a.2xlarge and 32 other(s)","commit":"5bdf9c3","controller":"disruption","namespace":"","name":"","reconcileID":"857f7bb5-a482-48e8-9c52-16a10823e2e4","command-id":"25beb85a-3020-4267-a525-5273e0afc7a7","reason":"underutilized"}
 ...
-{"level":"INFO","time":"2024-01-10T15:06:39.390Z","logger":"controller.nodeclaim.lifecycle","message":"launched nodeclaim","commit":"1072d3b","nodeclaim":"default-98tsh","nodepool":"default","provider-id":"aws:///eu-west-1a/i-0f329cada644371ec","instance-type":"c6g.2xlarge","zone":"eu-west-1a","capacity-type":"on-demand","allocatable":{"cpu":"7810m","ephemeral-storage":"17Gi","memory":"14003Mi","pods":"58","vpc.amazonaws.com/pod-eni":"38"}}
+{"level":"INFO","time":"2024-08-16T10:03:48.591Z","logger":"controller","message":"launched nodeclaim","commit":"5bdf9c3","controller":"nodeclaim.lifecycle","controllerGroup":"karpenter.sh","controllerKind":"NodeClaim","NodeClaim":{"name":"default-r9nzz"},"namespace":"","name":"default-r9nzz","reconcileID":"def551ff-c16e-4b1c-a137-f79df8724ded","provider-id":"aws:///eu-west-2a/i-0cefe0bfe63f80b39","instance-type":"c6g.2xlarge","zone":"eu-west-2a","capacity-type":"on-demand","allocatable":{"cpu":"7910m","ephemeral-storage":"17Gi","memory":"14103Mi","pods":"58","vpc.amazonaws.com/pod-eni":"38"}}
 ```
 The NGINX server and the 5-min job pods are rescheduled into the new c6g.2xlarge node, so **the job is restarted**, which will cause a disruption the job might not be prepared to handle like doing a checkpoint.
 
@@ -106,9 +106,9 @@ You should see something similar to this, where a new node just appeared:
 
 ```
 NAME                                         STATUS   ROLES    AGE   VERSION               INSTANCE-TYPE
-ip-10-0-125-209.eu-west-1.compute.internal   Ready    <none>   16d   v1.28.3-eks-e71965b   m4.large
-ip-10-0-46-139.eu-west-1.compute.internal    Ready    <none>   16d   v1.28.3-eks-e71965b   m4.large
-ip-10-0-47-60.eu-west-1.compute.internal     Ready    <none>   44s   v1.28.3-eks-e71965b   c6g.4xlarge
+ip-10-0-125-209.eu-west-1.compute.internal   Ready    <none>   16d   v1.30.2-eks-1552ad0   m4.large
+ip-10-0-46-139.eu-west-1.compute.internal    Ready    <none>   16d   v1.30.2-eks-1552ad0   m4.large
+ip-10-0-47-60.eu-west-1.compute.internal     Ready    <none>   44s   v1.30.2-eks-1552ad0   c6g.4xlarge
 ```
 
 Check the three new pods are running by executing:
@@ -135,13 +135,13 @@ kubectl -n karpenter logs -l app.kubernetes.io/name=karpenter --all-containers=t
 ```
 You should see the following events indicating that Karpenter identified the need of a new node, and that it selected an instance type and purchase option:
 ```
-{"level":"INFO","time":"2024-01-08T10:42:35.190Z","logger":"controller.provisioner","message":"found provisionable pod(s)","commit":"1072d3b","pods":"default/2-min-job-ml6qj, default/nginx-8467c776-bbl8w, default/5-min-job-9jc4b","duration":"89.747487ms"}
+{"level":"INFO","time":"2024-08-16T10:10:47.683Z","logger":"controller","message":"found provisionable pod(s)","commit":"5bdf9c3","controller":"provisioner","namespace":"","name":"","reconcileID":"d8e8907d-5b93-46bb-893a-63520f3ec12f","Pods":"default/2-min-job-czp5x","duration":"39.859328ms"}
 
-{"level":"INFO","time":"2024-01-08T10:42:35.190Z","logger":"controller.provisioner","message":"computed new nodeclaim(s) to fit pod(s)","commit":"1072d3b","nodeclaims":1,"pods":3}
+{"level":"INFO","time":"2024-08-16T10:10:47.683Z","logger":"controller","message":"computed new nodeclaim(s) to fit pod(s)","commit":"5bdf9c3","controller":"provisioner","namespace":"","name":"","reconcileID":"d8e8907d-5b93-46bb-893a-63520f3ec12f","nodeclaims":1,"pods":1}
 
-{"level":"INFO","time":"2024-01-08T10:42:35.224Z","logger":"controller.provisioner","message":"created nodeclaim","commit":"1072d3b","nodepool":"default","nodeclaim":"default-xzkfq","requests":{"cpu":"11260m","memory":"290Mi","pods":"8"},"instance-types":"c3.4xlarge, c3.8xlarge, c4.4xlarge, c5.4xlarge, c5a.12xlarge and 95 other(s)"}
+{"level":"INFO","time":"2024-08-16T10:10:47.699Z","logger":"controller","message":"created nodeclaim","commit":"5bdf9c3","controller":"provisioner","namespace":"","name":"","reconcileID":"d8e8907d-5b93-46bb-893a-63520f3ec12f","NodePool":{"name":"default"},"NodeClaim":{"name":"default-g4kgp"},"requests":{"cpu":"7260m","memory":"290Mi","pods":"6"},"instance-types":"c4.2xlarge, c5.2xlarge, c5.4xlarge, c5a.2xlarge, c5a.4xlarge and 55 other(s)"}
 ...
-{"level":"INFO","time":"2024-01-08T10:42:37.686Z","logger":"controller.nodeclaim.lifecycle","message":"launched nodeclaim","commit":"1072d3b","nodeclaim":"default-xzkfq","nodepool":"default","provider-id":"aws:///eu-west-1a/i-044f1f028b733d18a","instance-type":"c6g.4xlarge","zone":"eu-west-1a","capacity-type":"on-demand","allocatable":{"cpu":"15790m","ephemeral-storage":"17Gi","memory":"27222Mi","pods":"234","vpc.amazonaws.com/pod-eni":"54"}}
+{"level":"INFO","time":"2024-08-16T10:10:49.959Z","logger":"controller","message":"launched nodeclaim","commit":"5bdf9c3","controller":"nodeclaim.lifecycle","controllerGroup":"karpenter.sh","controllerKind":"NodeClaim","NodeClaim":{"name":"default-g4kgp"},"namespace":"","name":"default-g4kgp","reconcileID":"ff5b7f6e-c52e-495e-94b1-3a30385c3439","provider-id":"aws:///eu-west-2a/i-022a05d79bceda579","instance-type":"c6g.2xlarge","zone":"eu-west-2a","capacity-type":"on-demand","allocatable":{"cpu":"7910m","ephemeral-storage":"17Gi","memory":"14103Mi","pods":"58","vpc.amazonaws.com/pod-eni":"38"}}
 
 ```
 
@@ -172,7 +172,7 @@ Now, the total number of vCPU required by the running pods are **4 vCPU**:
 ```
 $> kubectl describe node <node_name>
 ...
-  Normal    DisruptionBlocked   36s karpenter   Cannot disrupt Node: Pod "default/5-min-job-9jc4b" has do not evict annotation
+  Normal    DisruptionBlocked   36s karpenter   Cannot disrupt Node: pod "default/2-min-job-czp5x" has "karpenter.sh/do-not-disrupt" annotation
 ```
 
 ### Consolidation Replace allowed after last job finishes
@@ -184,21 +184,21 @@ NAME        COMPLETIONS   DURATION   AGE
 ```
 Now, **it is possible to replace the node** by a cheaper and smaller instance because the the NGINX server can be disrupted as it does't contain the `karpenter.sh/do-not-disrupt: "true"` annotation. You can check this in the Karpenter logs terminal:
 ```
-{"level":"INFO","time":"2024-01-08T10:48:46.480Z","logger":"controller.disruption","message":"disrupting via consolidation replace, terminating 1 candidates ip-10-0-47-60.eu-west-1.compute.internal/c6g.4xlarge/on-demand and replacing with on-demand node from types c5n.2xlarge, r6a.2xlarge, m6a.2xlarge, m6id.xlarge, m7gd.xlarge and 103 other(s)","commit":"1072d3b"}
+{"level":"INFO","time":"2024-08-16T10:17:21.322Z","logger":"controller","message":"created nodeclaim","commit":"5bdf9c3","controller":"disruption","namespace":"","name":"","reconcileID":"1135db0e-45ef-4529-9492-63789a9837c6","NodePool":{"name":"default"},"NodeClaim":{"name":"default-9m4bv"},"requests":{"cpu":"2260m","memory":"290Mi","pods":"6"},"instance-types":"c4.xlarge, c5.xlarge, c5a.xlarge, c5d.xlarge, c5n.xlarge and 32 other(s)"}
 ...
-{"level":"INFO","time":"2024-01-08T10:48:48.675Z","logger":"controller.nodeclaim.lifecycle","message":"launched nodeclaim","commit":"1072d3b","nodeclaim":"default-7qxqp","nodepool":"default","provider-id":"aws:///eu-west-1b/i-0933fc4784ff30008","instance-type":"c6g.xlarge","zone":"eu-west-1b","capacity-type":"on-demand","allocatable":{"cpu":"3820m","ephemeral-storage":"17Gi","memory":"6425Mi","pods":"58","vpc.amazonaws.com/pod-eni":"18"}}
+{"level":"INFO","time":"2024-08-16T10:17:23.452Z","logger":"controller","message":"launched nodeclaim","commit":"5bdf9c3","controller":"nodeclaim.lifecycle","controllerGroup":"karpenter.sh","controllerKind":"NodeClaim","NodeClaim":{"name":"default-9m4bv"},"namespace":"","name":"default-9m4bv","reconcileID":"f0e0cc47-45a9-479c-a1c7-b5f0f0341026","provider-id":"aws:///eu-west-2a/i-0a4fa068af5550afa","instance-type":"c6g.xlarge","zone":"eu-west-2a","capacity-type":"on-demand","allocatable":{"cpu":"3920m","ephemeral-storage":"17Gi","memory":"6525Mi","pods":"58","vpc.amazonaws.com/pod-eni":"18"}}
 ...
-{"level":"INFO","time":"2024-01-08T10:49:30.787Z","logger":"controller.node.termination","message":"tainted node","commit":"1072d3b","node":"ip-10-0-47-60.eu-west-1.compute.internal"}
+{"level":"INFO","time":"2024-08-16T10:18:07.430Z","logger":"controller","message":"tainted node","commit":"5bdf9c3","controller":"node.termination","controllerGroup":"","controllerKind":"Node","Node":{"name":"ip-10-0-42-175.eu-west-2.compute.internal"},"namespace":"","name":"ip-10-0-42-175.eu-west-2.compute.internal","reconcileID":"a57044a6-f00f-41e5-a1ab-31e4b19dd838","taint.Key":"karpenter.sh/disrupted","taint.Value":"","taint.Effect":"NoSchedule"}
 
-{"level":"INFO","time":"2024-01-08T10:49:39.385Z","logger":"controller.node.termination","message":"deleted node","commit":"1072d3b","node":"ip-10-0-47-60.eu-west-1.compute.internal"}
+{"level":"INFO","time":"2024-08-16T10:18:50.331Z","logger":"controller","message":"deleted node","commit":"5bdf9c3","controller":"node.termination","controllerGroup":"","controllerKind":"Node","Node":{"name":"ip-10-0-42-175.eu-west-2.compute.internal"},"namespace":"","name":"ip-10-0-42-175.eu-west-2.compute.internal","reconcileID":"2a51acf8-702f-4c75-988d-92052d690b01"}
 ```
 Karpenter replaces the **c6g.4xlarge** (16 vCPU, 32 GiB) with a **c6g.xlarge** node (4 vCPU, 8 GiB), enough for the NGINX server: 
 ```
 $> kubectl get nodes --label-columns node.kubernetes.io/instance-type
 NAME                                         STATUS   ROLES    AGE   VERSION               INSTANCE-TYPE
-ip-10-0-125-209.eu-west-1.compute.internal   Ready    <none>   17d   v1.28.3-eks-e71965b   m4.large
-ip-10-0-46-139.eu-west-1.compute.internal    Ready    <none>   17d   v1.28.3-eks-e71965b   m4.large
-ip-10-0-85-30.eu-west-1.compute.internal     Ready    <none>   26s   v1.28.3-eks-e71965b   c6g.xlarge
+ip-10-0-125-209.eu-west-1.compute.internal   Ready    <none>   17d   v1.30.2-eks-1552ad0   m4.large
+ip-10-0-46-139.eu-west-1.compute.internal    Ready    <none>   17d   v1.30.2-eks-1552ad0   m4.large
+ip-10-0-85-30.eu-west-1.compute.internal     Ready    <none>   26s   v1.30.2-eks-1552ad0   c6g.xlarge
 ```
 Finally, you can check the NGINX server pod has been re-scheduled into the new pod:
 ```

--- a/blueprints/custom-ami/README.md
+++ b/blueprints/custom-ami/README.md
@@ -31,9 +31,14 @@ kubectl apply -f .
 
 Here's the important configuration block within the spec of an [`EC2NodeClass`](https://karpenter.sh/preview/concepts/nodeclasses/#specamiselectorterms): **spec.amiSelectorTerms**
 
-`spec.amiSelectorTerms` are used to configure custom AMIs for Karpenter to use, where the AMIs are discovered through ids, owners, name, and tags. AMI Selector Terms are **required**. If you were previously not specifying the AMIFamily field, having Karpenter default the AMIFamily to AL2, you will now have to specify AL2 explicitly.
+`amiSelectorTerms` are required and are used to configure AMIs for Karpenter to use. AMIs are discovered through alias, id, owner, name, and [tags](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Tags.html).
 
 If amiSelectorTerms match more than one AMI, Karpenter will automatically determine which AMI best fits the workloads on the launched worker node under the following constraints:
+
+- When launching nodes, Karpenter automatically determines which architecture a custom AMI is compatible with and will use images that match an instanceType’s requirements.
+  - Unless using an alias, Karpenter cannot detect requirements other than architecture. If you need to specify different AMIs for different kind of nodes (e.g. accelerated GPU AMIs), you should use a separate EC2NodeClass.
+- If multiple AMIs are found that can be used, Karpenter will choose the latest one.
+- If no AMIs are found that can be used, then no nodes will be provisioned.
 
 To select an AMI by name, use the `name` field in the selector term. To select an AMI by id, use the `id` field in the selector term. To ensure that AMIs are owned by the expected owner, use the `owner` field - you can use a combination of account aliases (e.g. self amazon, your-aws-account-name) and account IDs. If this is not set, it defaults to `self,amazon`.
 

--- a/blueprints/custom-ami/README.md
+++ b/blueprints/custom-ami/README.md
@@ -39,13 +39,13 @@ Here's the important configuration block within the spec of an [`EC2NodeClass`](
 
 ```
   amiSelectorTerms:
-    - name: "*amazon-eks-node-1.27-*"
+    - name: "*amazon-eks-node-1.30-*"
       owner: self
-    - name: "*amazon-eks-node-1.27-*"
+    - name: "*amazon-eks-node-1.30-*"
       owner: amazon
 ```
 
-***IMPORTANT NOTE:*** With this configuration, you're saying that you need to use the latest AMI available for an EKS cluster v1.27 which is either owned by you (customized) or Amazon (official image). We're  using a regular expression to have the flexibility to use AMIs for either `x86` or `Arm`, workloads that need GPUs, or a nodes with different OS like `Windows`. You're basically letting the workload (pod) to decide which type of node(s) it needs. If you don't have a custom AMI created by you in your account, Karpenter will use the official EKS AMI owned by Amazon.
+***IMPORTANT NOTE:*** With this configuration, you're saying that you need to use the latest AMI available for an EKS cluster v1.30 which is either owned by you (customized) or Amazon (official image). We're  using a regular expression to have the flexibility to use AMIs for either `x86` or `Arm`, workloads that need GPUs, or a nodes with different OS like `Windows`. You're basically letting the workload (pod) to decide which type of node(s) it needs. If you don't have a custom AMI created by you in your account, Karpenter will use the official EKS AMI owned by Amazon.
 
 ## Results
 After waiting for about one minute, you should see a machine ready, and all pods in a `Running` state, like this:
@@ -57,8 +57,8 @@ custom-ami-bdf66b777-2g27q   1/1     Running   0          2m2s
 custom-ami-bdf66b777-dbkls   1/1     Running   0          2m2s
 custom-ami-bdf66b777-rzlsz   1/1     Running   0          2m2s
 ❯ kubectl get nodeclaims
-NAME               TYPE       ZONE         NODE                                        READY   AGE
-custom-ami-2ht8b   m5.large   eu-west-1c   ip-10-0-103-91.eu-west-1.compute.internal   True    1m36s
+NAME               TYPE          CAPACITY    ZONE         NODE                                         READY   AGE
+custom-ami-jhdbh   c5a.large     spot        eu-west-2c   ip-10-0-117-230.eu-west-2.compute.internal   True    114s
 ```
 
 ## Cleanup

--- a/blueprints/custom-ami/README.md
+++ b/blueprints/custom-ami/README.md
@@ -31,7 +31,11 @@ kubectl apply -f .
 
 Here's the important configuration block within the spec of an [`EC2NodeClass`](https://karpenter.sh/preview/concepts/nodeclasses/#specamiselectorterms): **spec.amiSelectorTerms**
 
-`spec.amiSelectorTerms` are used to configure custom AMIs for Karpenter to use, where the AMIs are discovered through ids, owners, name, and tags. This field is optional, and Karpenter will use the latest **EKS-optimized AMIs** for the `AMIFamily` if no `amiSelectorTerms` are specified. To select an AMI by name, use the `name` field in the selector term. To select an AMI by id, use the `id` field in the selector term. To ensure that AMIs are owned by the expected owner, use the `owner` field - you can use a combination of account aliases (e.g. self amazon, your-aws-account-name) and account IDs. If this is not set, it defaults to `self,amazon`.
+`spec.amiSelectorTerms` are used to configure custom AMIs for Karpenter to use, where the AMIs are discovered through ids, owners, name, and tags. AMI Selector Terms are **required**. If you were previously not specifying the AMIFamily field, having Karpenter default the AMIFamily to AL2, you will now have to specify AL2 explicitly.
+
+If amiSelectorTerms match more than one AMI, Karpenter will automatically determine which AMI best fits the workloads on the launched worker node under the following constraints:
+
+To select an AMI by name, use the `name` field in the selector term. To select an AMI by id, use the `id` field in the selector term. To ensure that AMIs are owned by the expected owner, use the `owner` field - you can use a combination of account aliases (e.g. self amazon, your-aws-account-name) and account IDs. If this is not set, it defaults to `self,amazon`.
 
 > **Tip**
 > AMIs may be specified by any AWS tag, including Name. Selecting by tag

--- a/blueprints/custom-ami/custom-ami.yaml
+++ b/blueprints/custom-ami/custom-ami.yaml
@@ -1,27 +1,27 @@
-apiVersion: karpenter.k8s.aws/v1beta1
+apiVersion: karpenter.k8s.aws/v1
 kind: EC2NodeClass
 metadata:
   name: custom-ami-template
 spec:
   amiFamily: AL2
   amiSelectorTerms:
-  - name: '*amazon-eks-node-1.29-*'
-  role: "<<KARPENTER_NODE_IAM_ROLE_NAME>>"
+  - name: '*amazon-eks-node-1.30-*'
+  role: "karpenter-karpenter-blueprints"
   securityGroupSelectorTerms:
   - tags:
-      karpenter.sh/discovery: <<CLUSTER_NAME>>
+      karpenter.sh/discovery: karpenter-blueprints
   subnetSelectorTerms:
   - tags:
-      karpenter.sh/discovery: <<CLUSTER_NAME>>
+      karpenter.sh/discovery: karpenter-blueprints
 ---
-apiVersion: karpenter.sh/v1beta1
+apiVersion: karpenter.sh/v1
 kind: NodePool
 metadata:
   name: custom-ami
 spec:
   disruption:
-    consolidationPolicy: WhenUnderutilized
-    expireAfter: Never
+    consolidationPolicy: WhenEmptyOrUnderutilized
+    consolidateAfter: 1m
   limits:
     cpu: 1k
     memory: 500Gi
@@ -31,7 +31,9 @@ spec:
         intent: custom-ami
     spec:
       nodeClassRef:
+        group: karpenter.k8s.aws
         name: custom-ami-template
+        kind: EC2NodeClass
       requirements:
       - key: karpenter.k8s.aws/instance-hypervisor
         operator: NotIn

--- a/blueprints/custom-ami/custom-ami.yaml
+++ b/blueprints/custom-ami/custom-ami.yaml
@@ -6,13 +6,13 @@ spec:
   amiFamily: AL2
   amiSelectorTerms:
   - name: '*amazon-eks-node-1.30-*'
-  role: "karpenter-karpenter-blueprints"
+  role: "<<KARPENTER_NODE_IAM_ROLE_NAME>>"
   securityGroupSelectorTerms:
   - tags:
-      karpenter.sh/discovery: karpenter-blueprints
+      karpenter.sh/discovery: <<CLUSTER_NAME>>
   subnetSelectorTerms:
   - tags:
-      karpenter.sh/discovery: karpenter-blueprints
+      karpenter.sh/discovery: <<CLUSTER_NAME>>
 ---
 apiVersion: karpenter.sh/v1
 kind: NodePool

--- a/blueprints/disruption-budgets/README.md
+++ b/blueprints/disruption-budgets/README.md
@@ -24,9 +24,11 @@ spec:
   ...
   disruption:
     consolidationPolicy: WhenUnderutilized
-    expireAfter: 720h # 30 days
     budgets:
     - nodes: "20%"
+  template:
+    spec:
+      expireAfter: 720h # 30 days
 ```
 
 ### Do not disrupt between UTC 09:00 and 18:00 every day
@@ -58,7 +60,7 @@ You might apply this configuration if outside of core business hours you prefer 
 The following Disruption Budgets says, for a 4 hour timeframe from UTC 22:00 only disrupt 20% of nodes, but during normal operations (UTC 2:00 - 22:00) only disrupt 10% of nodes.
 
 ```
-apiVersion: karpenter.sh/v1beta1
+apiVersion: karpenter.sh/v1
 kind: NodePool
 metadata:
   name: default
@@ -89,7 +91,7 @@ As the first and second budget are active all the time, though 20% of nodes can 
 If multiple Budgets are active at the same time Karpenter will consider the most restrictive. You might consider multiple disruption budgets if you want to have a default disruption policy and would like an alternative policy at a specific time e.g. during maintenance windows allow more disruptions to roll-out new Amazon Machine Images faster.
 
 ```
-apiVersion: karpenter.sh/v1beta1
+apiVersion: karpenter.sh/v1
 kind: NodePool
 metadata:
   name: default
@@ -225,10 +227,10 @@ After modifying that budget for the NodePool you should observe the nodes drifti
 ```
 > kubectl get nodes -o wide -w
 
-ip-10-0-10-115.eu-west-1.compute.internal           Ready    ....  Bottlerocket OS 1.19.4 (aws-k8s-1.29)
-ip-10-0-10-176.eu-west-1.compute.internal           Ready    ....  Bottlerocket OS 1.19.4 (aws-k8s-1.29)
-ip-10-0-10-209.eu-west-1.compute.internal           Ready    ....  Bottlerocket OS 1.19.4 (aws-k8s-1.29)
-ip-10-0-10-84.eu-west-1.compute.internal            Ready    ....  Bottlerocket OS 1.19.4 (aws-k8s-1.29)
+ip-10-0-10-115.eu-west-1.compute.internal           Ready    ....  Bottlerocket OS 1.19.4 (aws-k8s-1.30)
+ip-10-0-10-176.eu-west-1.compute.internal           Ready    ....  Bottlerocket OS 1.19.4 (aws-k8s-1.30)
+ip-10-0-10-209.eu-west-1.compute.internal           Ready    ....  Bottlerocket OS 1.19.4 (aws-k8s-1.30)
+ip-10-0-10-84.eu-west-1.compute.internal            Ready    ....  Bottlerocket OS 1.19.4 (aws-k8s-1.30)
 ip-10-0-11-194.eu-west-1.compute.internal           Ready    ....  Amazon Linux 2
 ...
 ```

--- a/blueprints/disruption-budgets/README.md
+++ b/blueprints/disruption-budgets/README.md
@@ -53,7 +53,7 @@ spec:
       duration: 16h
 ```
 
- ### Multiple Budgets for Granular Control
+ ### Allow 20% disruptions during a maintenance window from UTC 22:00 to 2:00, but only 10% disruptions outside of a maintenance window
 
 By setting multiple disruption budgets, you can gain precise control over node disruptions. Karpenter will use the most restrictive budget applicable at any given time.
 
@@ -78,7 +78,7 @@ spec:
       duration: 20h
 ```
 
-### Multiple budgets defined
+### Multiple Budgets Defined
 
 The following configuration illustrates a NodePool with three disruption budgets:
 

--- a/blueprints/disruption-budgets/README.md
+++ b/blueprints/disruption-budgets/README.md
@@ -134,13 +134,16 @@ Let's say you want to control how nodes are upgraded when switching to Bottleroc
 To deploy the Karpenter NodePool and the sample workload, simply run this command:
 
 ```
+sed -i '' "s/<<CLUSTER_NAME>>/$CLUSTER_NAME/g" nodepool-restrictive-budget.yaml
+sed -i '' "s/<<KARPENTER_NODE_IAM_ROLE_NAME>>/$KARPENTER_NODE_IAM_ROLE_NAME/g" nodepool-restrictive-budget.yaml
 kubectl apply -f .
 ```
 
 You should see the following output:
 
 ```
-nodepool.karpenter.sh/default created
+nodepool.karpenter.sh/restrictive-budget created
+ec2nodeclass.karpenter.k8s.aws/restrictive-budget created
 deployment.apps/workload-multi-az-nodes created
 ```
 
@@ -154,24 +157,17 @@ ip-10-0-104-11.eu-west-2.compute.internal    Ready    <none>   13m    v1.30.2-ek
 ip-10-0-116-117.eu-west-2.compute.internal   Ready    <none>   13m    v1.30.2-eks-1552ad0
 ip-10-0-116-255.eu-west-2.compute.internal   Ready    <none>   13m    v1.30.2-eks-1552ad0
 ip-10-0-35-96.eu-west-2.compute.internal     Ready    <none>   13m    v1.30.2-eks-1552ad0
-ip-10-0-36-126.eu-west-2.compute.internal    Ready    <none>   157m   v1.30.2-eks-1552ad0
-ip-10-0-36-30.eu-west-2.compute.internal     Ready    <none>   13m    v1.30.2-eks-1552ad0
-ip-10-0-36-76.eu-west-2.compute.internal     Ready    <none>   13m    v1.30.2-eks-1552ad0
-ip-10-0-37-189.eu-west-2.compute.internal    Ready    <none>   13m    v1.30.2-eks-1552ad0
-ip-10-0-39-6.eu-west-2.compute.internal      Ready    <none>   13m    v1.30.2-eks-1552ad0
-ip-10-0-59-135.eu-west-2.compute.internal    Ready    <none>   13m    v1.30.2-eks-1552ad0
-ip-10-0-62-80.eu-west-2.compute.internal     Ready    <none>   13m    v1.30.2-eks-1552ad0
-ip-10-0-64-185.eu-west-2.compute.internal    Ready    <none>   157m   v1.30.2-eks-1552ad0
-ip-10-0-67-159.eu-west-2.compute.internal    Ready    <none>   26m    v1.30.2-eks-1552ad0
-ip-10-0-69-0.eu-west-2.compute.internal      Ready    <none>   13m    v1.30.2-eks-1552ad0
-ip-10-0-80-111.eu-west-2.compute.internal    Ready    <none>   13m    v1.30.2-eks-1552ad0
-ip-10-0-85-60.eu-west-2.compute.internal     Ready    <none>   13m    v1.30.2-eks-1552ad0
-ip-10-0-93-130.eu-west-2.compute.internal    Ready    <none>   13m    v1.30.2-eks-1552ad0
-ip-10-0-93-72.eu-west-2.compute.internal     Ready    <none>   13m    v1.30.2-eks-1552ad0
-ip-10-0-96-223.eu-west-2.compute.internal    Ready    <none>   13m    v1.30.2-eks-1552ad0
 ```
 
-Now, use `kubectl edit ec2nodeclass/default` and change the `.spec.amiFamily` from `AL2` to `Bottlerocket`. 
+Now, use `kubectl edit ec2nodeclass/restrictive-budget` and change the `.spec.amiSelectorTerms` alias from `al2@latest` to `bottlerocket@latest`. 
+
+or use the `kubectl patch` command.
+
+```
+kubectl patch ec2nodeclass restrictive-budget --type='json' -p='[
+  {"op": "replace", "path": "/spec/amiSelectorTerms/0/alias", "value": "bottlerocket@latest"}
+]'
+```
 
 ## Results
 
@@ -188,15 +184,6 @@ ip-10-0-104-11.eu-west-2.compute.internal    Ready    <none>   14m    v1.30.2-ek
 ip-10-0-116-117.eu-west-2.compute.internal   Ready    <none>   14m    v1.30.2-eks-1552ad0   10.0.116.117   <none>        Amazon Linux 2                 5.10.220-209.869.amzn2.aarch64    containerd://1.7.11
 ip-10-0-116-255.eu-west-2.compute.internal   Ready    <none>   14m    v1.30.2-eks-1552ad0   10.0.116.255   <none>        Amazon Linux 2                 5.10.220-209.869.amzn2.aarch64    containerd://1.7.11
 ip-10-0-35-96.eu-west-2.compute.internal     Ready    <none>   14m    v1.30.2-eks-1552ad0   10.0.35.96     <none>        Amazon Linux 2                 5.10.220-209.869.amzn2.aarch64    containerd://1.7.11
-ip-10-0-36-126.eu-west-2.compute.internal    Ready    <none>   157m   v1.30.2-eks-1552ad0   10.0.36.126    <none>        Amazon Linux 2023.5.20240805   6.1.102-108.177.amzn2023.x86_64   containerd://1.7.20
-ip-10-0-36-30.eu-west-2.compute.internal     Ready    <none>   14m    v1.30.2-eks-1552ad0   10.0.36.30     <none>        Amazon Linux 2                 5.10.220-209.869.amzn2.aarch64    containerd://1.7.11
-ip-10-0-36-76.eu-west-2.compute.internal     Ready    <none>   14m    v1.30.2-eks-1552ad0   10.0.36.76     <none>        Amazon Linux 2                 5.10.220-209.869.amzn2.aarch64    containerd://1.7.11
-ip-10-0-37-189.eu-west-2.compute.internal    Ready    <none>   14m    v1.30.2-eks-1552ad0   10.0.37.189    <none>        Amazon Linux 2                 5.10.220-209.869.amzn2.aarch64    containerd://1.7.11
-ip-10-0-39-6.eu-west-2.compute.internal      Ready    <none>   14m    v1.30.2-eks-1552ad0   10.0.39.6      <none>        Amazon Linux 2                 5.10.220-209.869.amzn2.aarch64    containerd://1.7.11
-ip-10-0-59-135.eu-west-2.compute.internal    Ready    <none>   14m    v1.30.2-eks-1552ad0   10.0.59.135    <none>        Amazon Linux 2                 5.10.220-209.869.amzn2.aarch64    containerd://1.7.11
-ip-10-0-62-80.eu-west-2.compute.internal     Ready    <none>   14m    v1.30.2-eks-1552ad0   10.0.62.80     <none>        Amazon Linux 2                 5.10.220-209.869.amzn2.aarch64    containerd://1.7.11
-ip-10-0-64-185.eu-west-2.compute.internal    Ready    <none>   157m   v1.30.2-eks-1552ad0   10.0.64.185    <none>        Amazon Linux 2023.5.20240805   6.1.102-108.177.amzn2023.x86_64   containerd://1.7.20
-...
 ```
 
 You will also see the following message in Kubernetes events stating disruptions are blocked:
@@ -218,20 +205,31 @@ budgets:
 
 If you edit the NodePool and replace the budget with the following, Karpenter will be able to Drift 20% of the Nodes.
 
+edit with kubectl `kubectl edit nodepool restrictive-budget`.
+
 ```
 - nodes: "20%"
 ```
+
+or use the `kubectl patch` command.
+```
+kubectl patch nodepool restrictive-budget --type='json' -p='[
+  {"op": "replace", "path": "/spec/disruption/budgets/0/nodes", "value": "20"}
+]'
+```
+
 
 After modifying that budget for the NodePool you should observe the nodes drifting and new nodes being provisioned with the latest Amazon EKS optimized Bottlerocket AMI.
 
 ```
 > kubectl get nodes -o wide -w
 
-ip-10-0-10-115.eu-west-1.compute.internal           Ready    ....  Bottlerocket OS 1.19.4 (aws-k8s-1.30)
-ip-10-0-10-176.eu-west-1.compute.internal           Ready    ....  Bottlerocket OS 1.19.4 (aws-k8s-1.30)
-ip-10-0-10-209.eu-west-1.compute.internal           Ready    ....  Bottlerocket OS 1.19.4 (aws-k8s-1.30)
-ip-10-0-10-84.eu-west-1.compute.internal            Ready    ....  Bottlerocket OS 1.19.4 (aws-k8s-1.30)
-ip-10-0-11-194.eu-west-1.compute.internal           Ready    ....  Amazon Linux 2
+NAME                                         STATUS   ROLES    AGE    VERSION               INTERNAL-IP    EXTERNAL-IP   OS-IMAGE                                KERNEL-VERSION                    CONTAINER-RUNTIME
+ip-10-0-102-16.eu-west-2.compute.internal    Ready    <none>   40s    v1.30.1-eks-e564799   10.0.102.16    <none>        Bottlerocket OS 1.20.5 (aws-k8s-1.30)   6.1.97                            containerd://1.6.34+bottlerocket
+ip-10-0-103-186.eu-west-2.compute.internal   Ready    <none>   82s    v1.30.1-eks-e564799   10.0.103.186   <none>        Bottlerocket OS 1.20.5 (aws-k8s-1.30)   6.1.97                            containerd://1.6.34+bottlerocket
+ip-10-0-40-150.eu-west-2.compute.internal    Ready    <none>   28s    v1.30.1-eks-e564799   10.0.40.150    <none>        Bottlerocket OS 1.20.5 (aws-k8s-1.30)   6.1.97  
+ip-10-0-104-138.eu-west-2.compute.internal   Ready    <none>   31s    v1.30.1-eks-e564799   10.0.104.138   <none>        Bottlerocket OS 1.20.5 (aws-k8s-1.30)   6.1.97                            containerd://1.6.34+bottlerocket
+ip-10-0-36-126.eu-west-2.compute.internal    Ready    <none>   5d7h   v1.30.2-eks-1552ad0   10.0.36.126    <none>        Amazon Linux 2023.5.20240805            6.1.102-108.177.amzn2023.x86_64   containerd://1.7.20
 ...
 ```
 

--- a/blueprints/disruption-budgets/README.md
+++ b/blueprints/disruption-budgets/README.md
@@ -107,11 +107,11 @@ spec:
       duration: 10m
 ```
 
-### Reasons
+### Disrupting by Reasons
 
 Karpenter allows specifying if a budget applies to any of `Drifted`, `Underutilized`, or `Empty`. When a budget has no reasons, it’s assumed that it applies to all reasons. When calculating allowed disruptions for a given reason, Karpenter will take the minimum of the budgets that have listed the reason or have left reasons undefined.
 
-### Drifted Nodes
+#### Only Drifted Nodes
 This example sets a budget that applies only to nodes classified as Drifted. During times when nodes are identified as Drifted, Karpenter will only disrupt up to 20% of those nodes.
 
 
@@ -129,7 +129,7 @@ spec:
       - "Drifted"
 ```
 
-### Underutilized Nodes
+#### Only Underutilized Nodes
 This example sets a budget that applies only to nodes classified as Underutilized. During times when nodes are identified as Underutilized, Karpenter will only disrupt up to 30% of those nodes.
 
 ```
@@ -146,7 +146,7 @@ spec:
       - "Underutilized"
 ```
 
-### Empty Nodes
+#### Only Empty Nodes
 This example sets a budget that applies only to nodes classified as Empty. During times when nodes are identified as Empty, Karpenter will only disrupt up to 10% of those nodes.
 
 ```
@@ -183,8 +183,8 @@ export KARPENTER_NODE_IAM_ROLE_NAME=$(terraform -chdir="../../cluster/terraform"
 To deploy the Karpenter NodePool and the sample workload, simply run this command:
 
 ```
-sed -i '' "s/<<CLUSTER_NAME>>/$CLUSTER_NAME/g" nodepool-restrictive-budget.yaml
-sed -i '' "s/<<KARPENTER_NODE_IAM_ROLE_NAME>>/$KARPENTER_NODE_IAM_ROLE_NAME/g" nodepool-restrictive-budget.yaml
+sed -i '' "s/<<CLUSTER_NAME>>/$CLUSTER_NAME/g" disruption-budgets.yaml
+sed -i '' "s/<<KARPENTER_NODE_IAM_ROLE_NAME>>/$KARPENTER_NODE_IAM_ROLE_NAME/g" disruption-budgets.yaml
 kubectl apply -f .
 ```
 
@@ -252,7 +252,10 @@ You will also see the following message in Kubernetes events stating disruptions
 ```
 > kubectl get events -w
 
-0s          Normal    DisruptionBlocked         nodepool/disruption-budget                        No allowed disruptions due to blocking budget
+0s          Normal    DisruptionBlocked               nodepool/restrictive-budget                       No allowed disruptions for disruption reason Drifted due to blocking budget
+0s          Normal    DisruptionBlocked               nodepool/restrictive-budget                       No allowed disruptions for disruption reason Underutilized due to blocking budget
+0s          Normal    DisruptionBlocked               nodepool/restrictive-budget                       No allowed disruptions for disruption reason Empty due to blocking budget
+0s          Normal    DisruptionBlocked               nodepool/restrictive-budget                       No allowed disruptions due to blocking budget
 ```
 
 This is because the NodePool defines the following budget which states, starting at UTC 00:00 everyday, for a time period of 24 hours no nodes can be voluntary drifted. This is a great fit when you want consolidation but might not want to apply it all the time.

--- a/blueprints/disruption-budgets/README.md
+++ b/blueprints/disruption-budgets/README.md
@@ -9,9 +9,9 @@ By applying a combination of disruptions budgets and Pod Disruptions Budgets (PD
 ## Examples
 The following provides a set of example disruption budgets:
 
-### Only interrupt a % of Karpenter managed nodes
+### Limit Disruptions to a Percentage of Nodes
 
-Applications or systems might be more affected by planned disruptions caused by consolidation. Some applications may find consolidation is either too aggressive, while other might be more fault tolerant and would rather optimize for cost. This configuration to only interrupt a percentage of managed nodes allows you to control the level of churn. This also applies for cases like expireAfter, where there is an intent to refresh nodes.
+To prevent disruptions from affecting more than a certain percentage of nodes in a NodePool
 
 The following Disruption Budgets says, at any-point in time only disrupt 20% of the Nodes managed by the NodePool. For instance, if there were 19 nodes owned by the NodePool, 4 disruptions would be allowed, rounding up from 19 * .2 = 3.8.
 
@@ -31,11 +31,9 @@ spec:
       expireAfter: 720h # 30 days
 ```
 
-### Do not disrupt between UTC 09:00 and 18:00 every day
+### No Disruptions During Peak Hours
 
-You might apply this configuration if you would like Karpenter to not disrupt workloads during times when the workload might be receiving peak traffic.
-
-The following Disruption Budgets says, for a 8 hour timeframe from UTC 9:00 don’t disrupt any nodes voluntary, otherwise disrupt only 20%.
+This configuration ensures that Karpenter avoids disrupting workloads during peak traffic periods. Specifically, it prevents disruptions from UTC 9:00 for an 8-hour window and limits disruptions to 20% outside of this window.
 
 ```
 apiVersion: karpenter.sh/v1
@@ -43,21 +41,24 @@ kind: NodePool
 metadata:
   name: default
 spec:
-...
   disruption:
     consolidationPolicy: WhenEmptyOrUnderutilized
     consolidateAfter: 1m
     budgets:
     - nodes: "0"
-      schedule: "0 0 * * *"
-      duration: 24h
+      schedule: "0 9 * * *"
+      duration: 8h
+    - nodes: "20%"
+      schedule: "0 17 * * *"
+      duration: 16h
 ```
 
-### Allow 20% disruptions during a maintenance window from UTC 22:00 to 2:00, but only 10% disruptions outside of a maintenance window
+ ### Multiple Budgets for Granular Control
 
-You might apply this configuration if outside of core business hours you prefer a higher set of disruptions to speed up the roll out of AMI updates for example.
+By setting multiple disruption budgets, you can gain precise control over node disruptions. Karpenter will use the most restrictive budget applicable at any given time.
 
-The following Disruption Budgets says, for a 4 hour timeframe from UTC 22:00 only disrupt 20% of nodes, but during normal operations (UTC 2:00 - 22:00) only disrupt 10% of nodes.
+In the following example, disruptions are limited to 20% of nodes during a 4-hour period starting from UTC 22:00. During the remaining hours (UTC 2:00 - 22:00), disruptions are limited to 10% of nodes.
+
 
 ```
 apiVersion: karpenter.sh/v1
@@ -65,7 +66,6 @@ kind: NodePool
 metadata:
   name: default
 spec:
-  ...
   disruption:
     consolidationPolicy: WhenEmptyOrUnderutilized
     consolidateAfter: 1m
@@ -80,15 +80,15 @@ spec:
 
 ### Multiple budgets defined
 
-The following Disruption Budgets is an example of a NodePool with three budgets defined.
+The following configuration illustrates a NodePool with three disruption budgets:
 
-* The first budget will only allow 20% of nodes owned by that NodePool to be disrupted.
-* The second budget acts as a ceiling to the previous budget, only allowing 5 disruptions
-* The last budget only blocks disruptions during the first 10 minutes of the day, where 0 disruptions are allowed.
+The first budget allows up to 20% of nodes to be disrupted at any time.
+The second budget imposes a maximum of 5 disruptions.
+The third budget blocks all disruptions during the first 10 minutes of each day.
 
-As the first and second budget are active all the time, though 20% of nodes can be disrupted only a maximum of 5 can be disrupted at anyone time.
+While the first and second budgets are always in effect, they work together to limit disruptions to a maximum of 5 nodes at any given time. Karpenter will apply the most restrictive budget when multiple budgets overlap, enabling flexible disruption policies for different scenarios, such as during maintenance windows.
 
-If multiple Budgets are active at the same time Karpenter will consider the most restrictive. You might consider multiple disruption budgets if you want to have a default disruption policy and would like an alternative policy at a specific time e.g. during maintenance windows allow more disruptions to roll-out new Amazon Machine Images faster.
+> **Note:** If multiple budgets are active at the same time, Karpenter will consider the most restrictive budget. You might consider using multiple disruption budgets to establish a default policy while providing an alternative policy for specific times, such as allowing more disruptions during maintenance windows to roll out new Amazon Machine Images faster.
 
 ```
 apiVersion: karpenter.sh/v1
@@ -96,7 +96,6 @@ kind: NodePool
 metadata:
   name: default
 spec:
-  ...
   disruption:
     consolidationPolicy: WhenEmptyOrUnderutilized
     consolidateAfter: 1m
@@ -112,15 +111,56 @@ spec:
 
 Karpenter allows specifying if a budget applies to any of `Drifted`, `Underutilized`, or `Empty`. When a budget has no reasons, it’s assumed that it applies to all reasons. When calculating allowed disruptions for a given reason, Karpenter will take the minimum of the budgets that have listed the reason or have left reasons undefined.
 
+### Drifted Nodes
+This example sets a budget that applies only to nodes classified as Drifted. During times when nodes are identified as Drifted, Karpenter will only disrupt up to 20% of those nodes.
+
 
 ```
+apiVersion: karpenter.sh/v1
+kind: NodePool
+metadata:
+  name: example-drifted
+spec:
   disruption:
     consolidationPolicy: WhenEmptyOrUnderutilized
     budgets:
     - nodes: "20%"
-      reasons: 
-      - "Empty"
+      reasons:
       - "Drifted"
+```
+
+### Underutilized Nodes
+This example sets a budget that applies only to nodes classified as Underutilized. During times when nodes are identified as Underutilized, Karpenter will only disrupt up to 30% of those nodes.
+
+```
+apiVersion: karpenter.sh/v1
+kind: NodePool
+metadata:
+  name: example-underutilized
+spec:
+  disruption:
+    consolidationPolicy: WhenEmptyOrUnderutilized
+    budgets:
+    - nodes: "30%"
+      reasons:
+      - "Underutilized"
+```
+
+### Empty Nodes
+This example sets a budget that applies only to nodes classified as Empty. During times when nodes are identified as Empty, Karpenter will only disrupt up to 10% of those nodes.
+
+```
+apiVersion: karpenter.sh/v1
+kind: NodePool
+metadata:
+  name: example-empty
+spec:
+  disruption:
+    consolidationPolicy: WhenEmptyOrUnderutilized
+    budgets:
+    - nodes: "10%"
+      reasons:
+      - "Empty"
 ```
 
 ## Requirements
@@ -130,6 +170,15 @@ Karpenter allows specifying if a budget applies to any of `Drifted`, `Underutili
 ## Deploy
 
 Let's say you want to control how nodes are upgraded when switching to Bottlerocket via Karpenter Drift, in this example we deploy a disruption budget, that prevents disruptions 24 hours a day 7 days a week. You can use the schedule and duration of the budget to control when disruptions via Drift can take place.
+
+If you're using the Terraform template provided in this repo, run the following commands to get the EKS cluster name and the IAM Role name for the Karpenter nodes:
+
+```
+export CLUSTER_NAME=$(terraform -chdir="../../cluster/terraform" output -raw cluster_name)
+export KARPENTER_NODE_IAM_ROLE_NAME=$(terraform -chdir="../../cluster/terraform" output -raw node_instance_role_name)
+```
+
+> ***NOTE***: If you're not using Terraform, you need to get those values manually. `CLUSTER_NAME` is the name of your EKS cluster (not the ARN). Karpenter auto-generates the [instance profile](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-ec2_instance-profiles) in your `EC2NodeClass` given the role that you specify in [spec.role](https://karpenter.sh/preview/concepts/nodeclasses/) with the placeholder `KARPENTER_NODE_IAM_ROLE_NAME`, which is a way to pass a single IAM role to the EC2 instance launched by the Karpenter `NodePool`. Typically, the instance profile name is the same as the IAM role(not the ARN).
 
 To deploy the Karpenter NodePool and the sample workload, simply run this command:
 
@@ -142,29 +191,34 @@ kubectl apply -f .
 You should see the following output:
 
 ```
-nodepool.karpenter.sh/restrictive-budget created
-ec2nodeclass.karpenter.k8s.aws/restrictive-budget created
-deployment.apps/workload-multi-az-nodes created
+nodepool.karpenter.sh/disruption-budget created
+ec2nodeclass.karpenter.k8s.aws/disruption-budget created
+deployment.apps/disruption-budget created
 ```
 
 You should now see new nodes provisioned in your Amazon EKS cluster:
 
 ```
 > kubectl get nodes
-
-ip-10-0-101-25.eu-west-2.compute.internal    Ready    <none>   13m    v1.30.2-eks-1552ad0
-ip-10-0-104-11.eu-west-2.compute.internal    Ready    <none>   13m    v1.30.2-eks-1552ad0
-ip-10-0-116-117.eu-west-2.compute.internal   Ready    <none>   13m    v1.30.2-eks-1552ad0
-ip-10-0-116-255.eu-west-2.compute.internal   Ready    <none>   13m    v1.30.2-eks-1552ad0
-ip-10-0-35-96.eu-west-2.compute.internal     Ready    <none>   13m    v1.30.2-eks-1552ad0
+NAME                                         STATUS   ROLES    AGE     VERSION
+ip-10-0-103-232.eu-west-2.compute.internal   Ready    <none>   2m8s    v1.30.2-eks-1552ad0
+ip-10-0-120-141.eu-west-2.compute.internal   Ready    <none>   2m44s   v1.30.2-eks-1552ad0
+ip-10-0-38-179.eu-west-2.compute.internal    Ready    <none>   2m8s    v1.30.2-eks-1552ad0
+ip-10-0-39-106.eu-west-2.compute.internal    Ready    <none>   2m18s   v1.30.2-eks-1552ad0
+ip-10-0-50-60.eu-west-2.compute.internal     Ready    <none>   17m     v1.30.2-eks-1552ad0
+ip-10-0-55-94.eu-west-2.compute.internal     Ready    <none>   2m47s   v1.30.2-eks-1552ad0
+ip-10-0-63-247.eu-west-2.compute.internal    Ready    <none>   2m40s   v1.30.2-eks-1552ad0
+ip-10-0-66-70.eu-west-2.compute.internal     Ready    <none>   17m     v1.30.2-eks-1552ad0
+ip-10-0-72-85.eu-west-2.compute.internal     Ready    <none>   2m50s   v1.30.2-eks-1552ad0
+ip-10-0-82-100.eu-west-2.compute.internal    Ready    <none>   2m29s   v1.30.2-eks-1552ad0
+ip-10-0-95-228.eu-west-2.compute.internal    Ready    <none>   2m19s   v1.30.2-eks-1552ad0
+ip-10-0-96-121.eu-west-2.compute.internal    Ready    <none>   2m26s   v1.30.2-eks-1552ad0
 ```
 
-Now, use `kubectl edit ec2nodeclass/restrictive-budget` and change the `.spec.amiSelectorTerms` alias from `al2@latest` to `bottlerocket@latest`. 
-
-or use the `kubectl patch` command.
+Now, use the `kubectl patch` command to change `spec.amiSelectorTerms` alias from `al2@latest` to `bottlerocket@latest`.
 
 ```
-kubectl patch ec2nodeclass restrictive-budget --type='json' -p='[
+kubectl patch ec2nodeclass disruption-budget --type='json' -p='[
   {"op": "replace", "path": "/spec/amiSelectorTerms/0/alias", "value": "bottlerocket@latest"}
 ]'
 ```
@@ -178,12 +232,19 @@ Karpenter will try to replace nodes via the Drift mechanism on an AMI change. Ho
 ```
 > kubectl get nodes -o wide -w
 
-NAME                                         STATUS   ROLES    AGE    VERSION               INTERNAL-IP    EXTERNAL-IP   OS-IMAGE                       KERNEL-VERSION                    CONTAINER-RUNTIME
-ip-10-0-101-25.eu-west-2.compute.internal    Ready    <none>   14m    v1.30.2-eks-1552ad0   10.0.101.25    <none>        Amazon Linux 2                 5.10.220-209.869.amzn2.aarch64    containerd://1.7.11
-ip-10-0-104-11.eu-west-2.compute.internal    Ready    <none>   14m    v1.30.2-eks-1552ad0   10.0.104.11    <none>        Amazon Linux 2                 5.10.220-209.869.amzn2.aarch64    containerd://1.7.11
-ip-10-0-116-117.eu-west-2.compute.internal   Ready    <none>   14m    v1.30.2-eks-1552ad0   10.0.116.117   <none>        Amazon Linux 2                 5.10.220-209.869.amzn2.aarch64    containerd://1.7.11
-ip-10-0-116-255.eu-west-2.compute.internal   Ready    <none>   14m    v1.30.2-eks-1552ad0   10.0.116.255   <none>        Amazon Linux 2                 5.10.220-209.869.amzn2.aarch64    containerd://1.7.11
-ip-10-0-35-96.eu-west-2.compute.internal     Ready    <none>   14m    v1.30.2-eks-1552ad0   10.0.35.96     <none>        Amazon Linux 2                 5.10.220-209.869.amzn2.aarch64    containerd://1.7.11
+NAME                                         STATUS   ROLES    AGE     VERSION               INTERNAL-IP    EXTERNAL-IP   OS-IMAGE                       KERNEL-VERSION                    CONTAINER-RUNTIME
+ip-10-0-103-232.eu-west-2.compute.internal   Ready    <none>   3m22s   v1.30.2-eks-1552ad0   10.0.103.232   <none>        Amazon Linux 2                 5.10.223-211.872.amzn2.aarch64    containerd://1.7.20
+ip-10-0-120-141.eu-west-2.compute.internal   Ready    <none>   3m58s   v1.30.2-eks-1552ad0   10.0.120.141   <none>        Amazon Linux 2                 5.10.223-211.872.amzn2.aarch64    containerd://1.7.20
+ip-10-0-38-179.eu-west-2.compute.internal    Ready    <none>   3m22s   v1.30.2-eks-1552ad0   10.0.38.179    <none>        Amazon Linux 2                 5.10.223-211.872.amzn2.aarch64    containerd://1.7.20
+ip-10-0-39-106.eu-west-2.compute.internal    Ready    <none>   3m32s   v1.30.2-eks-1552ad0   10.0.39.106    <none>        Amazon Linux 2                 5.10.223-211.872.amzn2.aarch64    containerd://1.7.20
+ip-10-0-50-60.eu-west-2.compute.internal     Ready    <none>   18m     v1.30.2-eks-1552ad0   10.0.50.60     <none>        Amazon Linux 2023.5.20240805   6.1.102-108.177.amzn2023.x86_64   containerd://1.7.20
+ip-10-0-55-94.eu-west-2.compute.internal     Ready    <none>   4m1s    v1.30.2-eks-1552ad0   10.0.55.94     <none>        Amazon Linux 2                 5.10.223-211.872.amzn2.aarch64    containerd://1.7.20
+ip-10-0-63-247.eu-west-2.compute.internal    Ready    <none>   3m54s   v1.30.2-eks-1552ad0   10.0.63.247    <none>        Amazon Linux 2                 5.10.223-211.872.amzn2.aarch64    containerd://1.7.20
+ip-10-0-66-70.eu-west-2.compute.internal     Ready    <none>   18m     v1.30.2-eks-1552ad0   10.0.66.70     <none>        Amazon Linux 2023.5.20240805   6.1.102-108.177.amzn2023.x86_64   containerd://1.7.20
+ip-10-0-72-85.eu-west-2.compute.internal     Ready    <none>   4m4s    v1.30.2-eks-1552ad0   10.0.72.85     <none>        Amazon Linux 2                 5.10.223-211.872.amzn2.x86_64     containerd://1.7.20
+ip-10-0-82-100.eu-west-2.compute.internal    Ready    <none>   3m43s   v1.30.2-eks-1552ad0   10.0.82.100    <none>        Amazon Linux 2                 5.10.223-211.872.amzn2.aarch64    containerd://1.7.20
+ip-10-0-95-228.eu-west-2.compute.internal    Ready    <none>   3m33s   v1.30.2-eks-1552ad0   10.0.95.228    <none>        Amazon Linux 2                 5.10.223-211.872.amzn2.aarch64    containerd://1.7.20
+ip-10-0-96-121.eu-west-2.compute.internal    Ready    <none>   3m40s   v1.30.2-eks-1552ad0   10.0.96.121    <none>        Amazon Linux 2                 5.10.223-211.872.amzn2.aarch64    containerd://1.7.20
 ```
 
 You will also see the following message in Kubernetes events stating disruptions are blocked:
@@ -191,7 +252,7 @@ You will also see the following message in Kubernetes events stating disruptions
 ```
 > kubectl get events -w
 
-0s Normal DisruptionBlocked nodepool/default No allowed disruptions due to blocking budget
+0s          Normal    DisruptionBlocked         nodepool/disruption-budget                        No allowed disruptions due to blocking budget
 ```
 
 This is because the NodePool defines the following budget which states, starting at UTC 00:00 everyday, for a time period of 24 hours no nodes can be voluntary drifted. This is a great fit when you want consolidation but might not want to apply it all the time.
@@ -205,40 +266,52 @@ budgets:
 
 If you edit the NodePool and replace the budget with the following, Karpenter will be able to Drift 20% of the Nodes.
 
-edit with kubectl `kubectl edit nodepool restrictive-budget`.
-
+Edit with the `kubectl patch` command.
 ```
-- nodes: "20%"
-```
-
-or use the `kubectl patch` command.
-```
-kubectl patch nodepool restrictive-budget --type='json' -p='[
+kubectl patch nodepool disruption-budget --type='json' -p='[
   {"op": "replace", "path": "/spec/disruption/budgets/0/nodes", "value": "20"}
 ]'
 ```
 
-
 After modifying that budget for the NodePool you should observe the nodes drifting and new nodes being provisioned with the latest Amazon EKS optimized Bottlerocket AMI.
 
 ```
-> kubectl get nodes -o wide -w
+> kubectl get nodes -o custom-columns=NAME:.metadata.name,OS-IMAGE:.status.nodeInfo.osImage
 
-NAME                                         STATUS   ROLES    AGE    VERSION               INTERNAL-IP    EXTERNAL-IP   OS-IMAGE                                KERNEL-VERSION                    CONTAINER-RUNTIME
-ip-10-0-102-16.eu-west-2.compute.internal    Ready    <none>   40s    v1.30.1-eks-e564799   10.0.102.16    <none>        Bottlerocket OS 1.20.5 (aws-k8s-1.30)   6.1.97                            containerd://1.6.34+bottlerocket
-ip-10-0-103-186.eu-west-2.compute.internal   Ready    <none>   82s    v1.30.1-eks-e564799   10.0.103.186   <none>        Bottlerocket OS 1.20.5 (aws-k8s-1.30)   6.1.97                            containerd://1.6.34+bottlerocket
-ip-10-0-40-150.eu-west-2.compute.internal    Ready    <none>   28s    v1.30.1-eks-e564799   10.0.40.150    <none>        Bottlerocket OS 1.20.5 (aws-k8s-1.30)   6.1.97  
-ip-10-0-104-138.eu-west-2.compute.internal   Ready    <none>   31s    v1.30.1-eks-e564799   10.0.104.138   <none>        Bottlerocket OS 1.20.5 (aws-k8s-1.30)   6.1.97                            containerd://1.6.34+bottlerocket
-ip-10-0-36-126.eu-west-2.compute.internal    Ready    <none>   5d7h   v1.30.2-eks-1552ad0   10.0.36.126    <none>        Amazon Linux 2023.5.20240805            6.1.102-108.177.amzn2023.x86_64   containerd://1.7.20
-...
+NAME                                         OS-IMAGE
+ip-10-0-103-176.eu-west-2.compute.internal   Bottlerocket OS 1.20.5 (aws-k8s-1.30)
+ip-10-0-106-25.eu-west-2.compute.internal    Bottlerocket OS 1.20.5 (aws-k8s-1.30)
+ip-10-0-108-51.eu-west-2.compute.internal    Bottlerocket OS 1.20.5 (aws-k8s-1.30)
+ip-10-0-115-104.eu-west-2.compute.internal   Bottlerocket OS 1.20.5 (aws-k8s-1.30)
+ip-10-0-116-220.eu-west-2.compute.internal   Bottlerocket OS 1.20.5 (aws-k8s-1.30)
+ip-10-0-121-123.eu-west-2.compute.internal   Bottlerocket OS 1.20.5 (aws-k8s-1.30)
+ip-10-0-43-37.eu-west-2.compute.internal     Bottlerocket OS 1.20.5 (aws-k8s-1.30)
+ip-10-0-50-60.eu-west-2.compute.internal     Amazon Linux 2023.5.20240805
+ip-10-0-57-199.eu-west-2.compute.internal    Bottlerocket OS 1.20.5 (aws-k8s-1.30)
+ip-10-0-59-82.eu-west-2.compute.internal     Bottlerocket OS 1.20.5 (aws-k8s-1.30)
+ip-10-0-62-198.eu-west-2.compute.internal    Bottlerocket OS 1.20.5 (aws-k8s-1.30)
+ip-10-0-62-228.eu-west-2.compute.internal    Bottlerocket OS 1.20.5 (aws-k8s-1.30)
+ip-10-0-66-249.eu-west-2.compute.internal    Bottlerocket OS 1.20.5 (aws-k8s-1.30)
+ip-10-0-66-70.eu-west-2.compute.internal     Amazon Linux 2023.5.20240805
+ip-10-0-67-142.eu-west-2.compute.internal    Bottlerocket OS 1.20.5 (aws-k8s-1.30)
+ip-10-0-67-203.eu-west-2.compute.internal    Bottlerocket OS 1.20.5 (aws-k8s-1.30)
+ip-10-0-67-255.eu-west-2.compute.internal    Bottlerocket OS 1.20.5 (aws-k8s-1.30)
+ip-10-0-68-97.eu-west-2.compute.internal     Bottlerocket OS 1.20.5 (aws-k8s-1.30)
+ip-10-0-70-55.eu-west-2.compute.internal     Bottlerocket OS 1.20.5 (aws-k8s-1.30)
+ip-10-0-73-112.eu-west-2.compute.internal    Bottlerocket OS 1.20.5 (aws-k8s-1.30)
+ip-10-0-75-130.eu-west-2.compute.internal    Bottlerocket OS 1.20.5 (aws-k8s-1.30)
+ip-10-0-77-110.eu-west-2.compute.internal    Bottlerocket OS 1.20.5 (aws-k8s-1.30)
+ip-10-0-78-43.eu-west-2.compute.internal     Bottlerocket OS 1.20.5 (aws-k8s-1.30)
+ip-10-0-91-17.eu-west-2.compute.internal     Bottlerocket OS 1.20.5 (aws-k8s-1.30)
+ip-10-0-97-201.eu-west-2.compute.internal    Bottlerocket OS 1.20.5 (aws-k8s-1.30)
 ```
 
 You will also see the following message in Kubernetes events stating a node has been drifted:
 
 ```
-0s          Normal    DisruptionTerminating           node/ip-10-0-10-83.eu-west-1.compute.internal   Disrupting Node: Drift/Delete
-0s          Normal    DisruptionTerminating           nodeclaim/default-lxx5r                          Disrupting NodeClaim: Drift/Delete
-0s          Normal    RemovingNode                    node/ip-10-0-10-83.eu-west-1.compute.internal   Node ip-10-0-10-83.eu-west-1.compute.internal event: Removing Node ip-10-0-10-83.eu-west-1.compute.internal from Controller
+0s       Normal    DisruptionTerminating        node/ip-10-0-96-121.eu-west-2.compute.internal    Disrupting Node: Drifted/Delete
+0s       Warning   InstanceTerminating          node/ip-10-0-96-121.eu-west-2.compute.internal    Instance is terminating
+0s       Normal    RemovingNode                 node/ip-10-0-96-121.eu-west-2.compute.internal    Node ip-10-0-96-121.eu-west-2.compute.internal event: Removing Node ip-10-0-96-121.eu-west-2.compute.internal from Controller
 ```
 
 ## Clean-up

--- a/blueprints/disruption-budgets/disruption-budgets.yaml
+++ b/blueprints/disruption-budgets/disruption-budgets.yaml
@@ -1,7 +1,7 @@
 apiVersion: karpenter.sh/v1
 kind: NodePool
 metadata:
-  name: restrictive-budget
+  name: disruption-budget
 spec:
   limits:
     cpu: 100
@@ -9,11 +9,11 @@ spec:
   template:
     metadata:
       labels:
-        intent: apps
+        intent: disruption-budget
     spec:
       nodeClassRef:
         group: karpenter.k8s.aws
-        name: restrictive-budget
+        name: disruption-budget
         kind: EC2NodeClass
       requirements:
         - key: karpenter.sh/capacity-type
@@ -40,7 +40,7 @@ spec:
 apiVersion: karpenter.k8s.aws/v1
 kind: EC2NodeClass
 metadata:
-  name: restrictive-budget
+  name: disruption-budget
 spec:
   amiSelectorTerms: 
   - alias: al2@latest

--- a/blueprints/disruption-budgets/nodepool-restrictive-budget.yaml
+++ b/blueprints/disruption-budgets/nodepool-restrictive-budget.yaml
@@ -1,4 +1,4 @@
-apiVersion: karpenter.sh/v1beta1
+apiVersion: karpenter.sh/v1
 kind: NodePool
 metadata:
   name: default
@@ -12,7 +12,9 @@ spec:
         intent: apps
     spec:
       nodeClassRef:
+        group: karpenter.k8s.aws
         name: default
+        kind: EC2NodeClass
       requirements:
         - key: karpenter.sh/capacity-type
           operator: In
@@ -26,9 +28,10 @@ spec:
         - key: karpenter.k8s.aws/instance-hypervisor
           operator: In
           values: ["nitro"]
+      expireAfter: 720h
   disruption:
-    consolidationPolicy: WhenUnderutilized
-    expireAfter: 720h
+    consolidationPolicy: WhenEmptyOrUnderutilized
+    consolidateAfter: 1m
     budgets:
     - nodes: "0"
       schedule: "0 0 * * *"

--- a/blueprints/disruption-budgets/nodepool-restrictive-budget.yaml
+++ b/blueprints/disruption-budgets/nodepool-restrictive-budget.yaml
@@ -1,7 +1,7 @@
 apiVersion: karpenter.sh/v1
 kind: NodePool
 metadata:
-  name: default
+  name: restrictive-budget
 spec:
   limits:
     cpu: 100
@@ -13,7 +13,7 @@ spec:
     spec:
       nodeClassRef:
         group: karpenter.k8s.aws
-        name: default
+        name: restrictive-budget
         kind: EC2NodeClass
       requirements:
         - key: karpenter.sh/capacity-type
@@ -36,3 +36,18 @@ spec:
     - nodes: "0"
       schedule: "0 0 * * *"
       duration: 24h
+---
+apiVersion: karpenter.k8s.aws/v1
+kind: EC2NodeClass
+metadata:
+  name: restrictive-budget
+spec:
+  amiSelectorTerms: 
+  - alias: al2@latest
+  role: "<<KARPENTER_NODE_IAM_ROLE_NAME>>"
+  securityGroupSelectorTerms:
+  - tags:
+      karpenter.sh/discovery: <<CLUSTER_NAME>>
+  subnetSelectorTerms:
+  - tags:
+      karpenter.sh/discovery: <<CLUSTER_NAME>>

--- a/blueprints/disruption-budgets/workload.yaml
+++ b/blueprints/disruption-budgets/workload.yaml
@@ -1,21 +1,21 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: workload-multi-az-nodes
+  name: disruption-budget
 spec:
   replicas: 30
   selector:
     matchLabels:
-      app: workload-multi-az-nodes
+      intent: disruption-budget
   template:
     metadata:
       labels:
-        app: workload-multi-az-nodes
+        intent: disruption-budget
     spec:
       nodeSelector:
-        intent: apps
+        intent: disruption-budget
       containers:
-      - name: workload-multi-az-nodes
+      - name: disruption-budget
         image: public.ecr.aws/eks-distro/kubernetes/pause:3.7
         imagePullPolicy: Always
         resources:
@@ -25,13 +25,13 @@ spec:
       topologySpreadConstraints:
         - labelSelector:
             matchLabels:
-              app: workload-multi-az-nodes
+              intent: disruption-budget
           maxSkew: 1
           topologyKey: kubernetes.io/hostname
           whenUnsatisfiable: ScheduleAnyway
         - labelSelector:
             matchLabels:
-              app: workload-multi-az-nodes
+              intent: disruption-budget
           maxSkew: 1
           topologyKey: topology.kubernetes.io/zone
           whenUnsatisfiable: ScheduleAnyway

--- a/blueprints/graviton/README.md
+++ b/blueprints/graviton/README.md
@@ -56,7 +56,7 @@ NAME                                         STATUS   ROLES    AGE     VERSION  
 ip-10-0-120-103.eu-west-2.compute.internal   Ready    <none>   5m51s   v1.30.2-eks-1552ad0   on-demand       c6g.2xlarge     default    eu-west-2c
 ```
 
-Notice that now Karpenter decided to launch a `m6g.xlarge` Spot instance because the workload and the NodePool support both pricing models, and the one that has a better price at this moment was a Graviton Spot instance.
+Notice that now Karpenter decided to launch a `c6g.2xlarge` Spot instance because the workload and the NodePool support both pricing models, and the one that has a better price at this moment was a Graviton Spot instance.
 
 ## Cleanup
 

--- a/blueprints/graviton/README.md
+++ b/blueprints/graviton/README.md
@@ -52,9 +52,8 @@ kubectl get nodes -L karpenter.sh/capacity-type,beta.kubernetes.io/instance-type
 You should see something similar to this:
 
 ```
-NAME                                        STATUS   ROLES    AGE   VERSION               CAPACITY-TYPE   INSTANCE-TYPE   NODEPOOL   ZONE
-ip-10-0-66-182.eu-west-1.compute.internal   Ready    <none>   34m   v1.28.1-eks-43840fb   on-demand       c6g.xlarge      default            eu-west-1b
-ip-10-0-74-114.eu-west-1.compute.internal   Ready    <none>   31m   v1.28.1-eks-43840fb   spot            m6g.xlarge      default            eu-west-1b
+NAME                                         STATUS   ROLES    AGE     VERSION               CAPACITY-TYPE   INSTANCE-TYPE   NODEPOOL   ZONE
+ip-10-0-120-103.eu-west-2.compute.internal   Ready    <none>   5m51s   v1.30.2-eks-1552ad0   on-demand       c6g.2xlarge     default    eu-west-2c
 ```
 
 Notice that now Karpenter decided to launch a `m6g.xlarge` Spot instance because the workload and the NodePool support both pricing models, and the one that has a better price at this moment was a Graviton Spot instance.

--- a/blueprints/ha-az-nodes/README.md
+++ b/blueprints/ha-az-nodes/README.md
@@ -33,13 +33,24 @@ kubectl get nodes -L karpenter.sh/capacity-type,beta.kubernetes.io/instance-type
 You should see an output similar to this:
 
 ```
-NAME                                         STATUS   ROLES    AGE     VERSION               CAPACITY-TYPE   INSTANCE-TYPE   ZONE
-ip-10-0-104-252.eu-west-1.compute.internal   Ready    <none>   3m13s   v1.28.1-eks-43840fb   spot            m6g.xlarge      eu-west-1a
-ip-10-0-63-60.eu-west-1.compute.internal     Ready    <none>   3m7s    v1.28.1-eks-43840fb   spot            m6g.xlarge      eu-west-1a
-ip-10-0-99-253.eu-west-1.compute.internal    Ready    <none>   3m11s   v1.28.1-eks-43840fb   spot            m6g.xlarge      eu-west-1a
-ip-10-0-69-148.eu-west-1.compute.internal    Ready    <none>   3m8s    v1.28.1-eks-43840fb   spot            m6g.xlarge      eu-west-1b
-ip-10-0-91-218.eu-west-1.compute.internal    Ready    <none>   3m10s   v1.28.1-eks-43840fb   spot            m6g.xlarge      eu-west-1b
-ip-10-0-92-181.eu-west-1.compute.internal    Ready    <none>   3m12s   v1.28.1-eks-43840fb   spot            c6i.xlarge      eu-west-1b
+NAME                                         STATUS   ROLES    AGE     VERSION               CAPACITY-TYPE   INSTANCE-TYPE   NODEPOOL   ZONE
+ip-10-0-120-103.eu-west-2.compute.internal   Ready    <none>   8m37s   v1.30.2-eks-1552ad0   on-demand       c6g.2xlarge     default    eu-west-2c
+ip-10-0-37-198.eu-west-2.compute.internal    Ready    <none>   17s     v1.30.2-eks-1552ad0   spot            m7g.xlarge      default    eu-west-2a
+ip-10-0-37-31.eu-west-2.compute.internal     Ready    <none>   18s     v1.30.2-eks-1552ad0   spot            m7g.xlarge      default    eu-west-2a
+ip-10-0-40-3.eu-west-2.compute.internal      Ready    <none>   15s     v1.30.2-eks-1552ad0   spot            m7g.xlarge      default    eu-west-2a
+ip-10-0-42-68.eu-west-2.compute.internal     Ready    <none>   19s     v1.30.2-eks-1552ad0   spot            m7g.xlarge      default    eu-west-2a
+ip-10-0-42-79.eu-west-2.compute.internal     Ready    <none>   13s     v1.30.2-eks-1552ad0   spot            m7g.xlarge      default    eu-west-2a
+ip-10-0-44-133.eu-west-2.compute.internal    Ready    <none>   15s     v1.30.2-eks-1552ad0   spot            m7g.xlarge      default    eu-west-2a
+ip-10-0-45-41.eu-west-2.compute.internal     Ready    <none>   19s     v1.30.2-eks-1552ad0   spot            m7g.xlarge      default    eu-west-2a
+ip-10-0-47-216.eu-west-2.compute.internal    Ready    <none>   22s     v1.30.2-eks-1552ad0   spot            m7g.xlarge      default    eu-west-2a
+ip-10-0-52-31.eu-west-2.compute.internal     Ready    <none>   18s     v1.30.2-eks-1552ad0   spot            m7g.xlarge      default    eu-west-2a
+ip-10-0-56-207.eu-west-2.compute.internal    Ready    <none>   16s     v1.30.2-eks-1552ad0   spot            m7g.xlarge      default    eu-west-2a
+ip-10-0-70-74.eu-west-2.compute.internal     Ready    <none>   20s     v1.30.2-eks-1552ad0   spot            c7g.xlarge      default    eu-west-2b
+ip-10-0-77-172.eu-west-2.compute.internal    Ready    <none>   18s     v1.30.2-eks-1552ad0   spot            c7g.xlarge      default    eu-west-2b
+ip-10-0-78-211.eu-west-2.compute.internal    Ready    <none>   14s     v1.30.2-eks-1552ad0   spot            r6g.xlarge      default    eu-west-2b
+ip-10-0-78-239.eu-west-2.compute.internal    Ready    <none>   21s     v1.30.2-eks-1552ad0   spot            m7g.xlarge      default    eu-west-2b
+ip-10-0-83-77.eu-west-2.compute.internal     Ready    <none>   13s     v1.30.2-eks-1552ad0   spot            c5a.xlarge      default    eu-west-2b
+ip-10-0-91-96.eu-west-2.compute.internal     Ready    <none>   16s     v1.30.2-eks-1552ad0   spot            c6gd.xlarge     default    eu-west-2b
 ```
 
 As you can see, pods were spread within AZs (1a and 1b) because of the `topology.kubernetes.io/zone` TSC. But at the same time, pods were spread within multiple nodes in each AZ because of the `kubernetes.io/hostname` TSC.

--- a/blueprints/multi-ebs/README.md
+++ b/blueprints/multi-ebs/README.md
@@ -74,19 +74,19 @@ The output should be similar to this:
                 {
                     "DeviceName": "/dev/xvda",
                     "Ebs": {
-                        "AttachTime": "2023-09-08T12:32:46+00:00",
+                        "AttachTime": "2024-08-16T12:39:36+00:00",
                         "DeleteOnTermination": true,
                         "Status": "attached",
-                        "VolumeId": "vol-05d723169c01028d1"
+                        "VolumeId": "vol-0561b68b188d4e63a"
                     }
                 },
                 {
                     "DeviceName": "/dev/xvdb",
                     "Ebs": {
-                        "AttachTime": "2023-09-08T12:32:46+00:00",
+                        "AttachTime": "2024-08-16T12:39:36+00:00",
                         "DeleteOnTermination": true,
                         "Status": "attached",
-                        "VolumeId": "vol-0af5ebb6cc0ba5c11"
+                        "VolumeId": "vol-0ca5ca8b749f6bed0"
                     }
                 }
             ]

--- a/blueprints/multi-ebs/multi-ebs.yaml
+++ b/blueprints/multi-ebs/multi-ebs.yaml
@@ -70,10 +70,10 @@ spec:
       deleteOnTermination: true
       volumeSize: 100Gi
       volumeType: gp3
-  role: "karpenter-karpenter-blueprints"
+  role: "<<KARPENTER_NODE_IAM_ROLE_NAME>>"
   securityGroupSelectorTerms:
   - tags:
-      karpenter.sh/discovery: karpenter-blueprints
+      karpenter.sh/discovery: <<CLUSTER_NAME>>
   subnetSelectorTerms:
   - tags:
-      karpenter.sh/discovery: karpenter-blueprints
+      karpenter.sh/discovery: <<CLUSTER_NAME>>

--- a/blueprints/multi-ebs/multi-ebs.yaml
+++ b/blueprints/multi-ebs/multi-ebs.yaml
@@ -1,11 +1,11 @@
-apiVersion: karpenter.sh/v1beta1
+apiVersion: karpenter.sh/v1
 kind: NodePool
 metadata:
   name: multi-ebs
 spec:
   disruption:
-    consolidationPolicy: WhenUnderutilized
-    expireAfter: 168h0m0s
+    consolidationPolicy: WhenEmptyOrUnderutilized
+    consolidateAfter: 1m
   limits:
     cpu: 1k
     memory: 500Gi
@@ -14,8 +14,11 @@ spec:
       labels:
         intent: multi-ebs
     spec:
+      expireAfter: 168h0m0s
       nodeClassRef:
+        group: karpenter.k8s.aws
         name: multi-ebs
+        kind: EC2NodeClass
       requirements:
       - key: karpenter.k8s.aws/instance-category
         operator: In
@@ -48,12 +51,14 @@ spec:
         values:
         - amd64
 ---
-apiVersion: karpenter.k8s.aws/v1beta1
+apiVersion: karpenter.k8s.aws/v1
 kind: EC2NodeClass
 metadata:
   name: multi-ebs
 spec:
   amiFamily: AL2
+  amiSelectorTerms: 
+  - alias: al2@latest
   blockDeviceMappings:
   - deviceName: /dev/xvda
     ebs:
@@ -65,10 +70,10 @@ spec:
       deleteOnTermination: true
       volumeSize: 100Gi
       volumeType: gp3
-  role: "<<KARPENTER_NODE_IAM_ROLE_NAME>>"
+  role: "karpenter-karpenter-blueprints"
   securityGroupSelectorTerms:
   - tags:
-      karpenter.sh/discovery: <<CLUSTER_NAME>>
+      karpenter.sh/discovery: karpenter-blueprints
   subnetSelectorTerms:
   - tags:
-      karpenter.sh/discovery: <<CLUSTER_NAME>>
+      karpenter.sh/discovery: karpenter-blueprints

--- a/blueprints/od-spot-split/README.md
+++ b/blueprints/od-spot-split/README.md
@@ -43,16 +43,13 @@ kubectl get nodes -L karpenter.sh/capacity-type,beta.kubernetes.io/instance-type
 You should see an output similar to this:
 
 ```
-NAME                                         STATUS   ROLES    AGE   VERSION               CAPACITY-TYPE   INSTANCE-TYPE   NODEPOOL   ZONE
-ip-10-0-103-229.eu-west-1.compute.internal   Ready    <none>   42s   v1.28.3-eks-4f4795d   spot            c5.large        node-spot          eu-west-1c
-ip-10-0-33-163.eu-west-1.compute.internal    Ready    <none>   26s   v1.28.3-eks-4f4795d   spot            c7a.medium      node-spot          eu-west-1a
-ip-10-0-40-137.eu-west-1.compute.internal    Ready    <none>   49s   v1.28.3-eks-4f4795d   spot            c7a.medium      node-spot          eu-west-1a
-ip-10-0-45-167.eu-west-1.compute.internal    Ready    <none>   49s   v1.28.3-eks-4f4795d   spot            c7a.medium      node-spot          eu-west-1a
-ip-10-0-50-176.eu-west-1.compute.internal    Ready    <none>   40s   v1.28.3-eks-4f4795d   spot            c7a.medium      node-spot          eu-west-1a
-ip-10-0-53-132.eu-west-1.compute.internal    Ready    <none>   48s   v1.28.3-eks-4f4795d   on-demand       c7a.medium      node-od            eu-west-1a
-ip-10-0-54-108.eu-west-1.compute.internal    Ready    <none>   48s   v1.28.3-eks-4f4795d   spot            c7a.medium      node-spot          eu-west-1a
-ip-10-0-58-153.eu-west-1.compute.internal    Ready    <none>   39s   v1.28.3-eks-4f4795d   on-demand       c7a.medium      node-od            eu-west-1a
-ip-10-0-59-78.eu-west-1.compute.internal     Ready    <none>   31s   v1.28.3-eks-4f4795d   spot            m7a.medium      node-spot          eu-west-1a
+NAME                                         STATUS   ROLES    AGE   VERSION               CAPACITY-TYPE   INSTANCE-TYPE   NODEPOOL    ZONE
+ip-10-0-100-193.eu-west-2.compute.internal   Ready    <none>   22s   v1.30.2-eks-1552ad0   on-demand       c6a.large       node-od     eu-west-2c
+ip-10-0-127-154.eu-west-2.compute.internal   Ready    <none>   23m   v1.30.2-eks-1552ad0   on-demand       c6g.xlarge      default     eu-west-2c
+ip-10-0-74-242.eu-west-2.compute.internal    Ready    <none>   12s   v1.30.2-eks-1552ad0   spot            c6a.large       node-spot   eu-west-2b
+ip-10-0-81-86.eu-west-2.compute.internal     Ready    <none>   21s   v1.30.2-eks-1552ad0   spot            c6a.large       node-spot   eu-west-2b
+ip-10-0-94-203.eu-west-2.compute.internal    Ready    <none>   19s   v1.30.2-eks-1552ad0   spot            c6a.large       node-spot   eu-west-2b
+ip-10-0-94-213.eu-west-2.compute.internal    Ready    <none>   23s   v1.30.2-eks-1552ad0   spot            c6a.large       node-spot   eu-west-2b
 ```
 
 As you can see, pods were spread within the `spot` and `od` nodepools because of the `capacity-spread` TSC:

--- a/blueprints/od-spot-split/od-spot.yaml
+++ b/blueprints/od-spot-split/od-spot.yaml
@@ -1,11 +1,11 @@
-apiVersion: karpenter.sh/v1beta1
+apiVersion: karpenter.sh/v1
 kind: NodePool
 metadata:
   name: node-od
 spec:
   disruption:
-    consolidationPolicy: WhenUnderutilized
-    expireAfter: 168h0m0s
+    consolidationPolicy: WhenEmptyOrUnderutilized
+    consolidateAfter: 1m
   limits:
     cpu: 1k
     memory: 500Gi
@@ -14,8 +14,11 @@ spec:
       labels:
         intent: apps
     spec:
+      expireAfter: 168h0m0s
       nodeClassRef:
+        group: karpenter.k8s.aws
         name: default
+        kind: EC2NodeClass
       requirements:
       - key: capacity-spread
         operator: In
@@ -48,14 +51,14 @@ spec:
         key: intent
         value: workload-split
 ---
-apiVersion: karpenter.sh/v1beta1
+apiVersion: karpenter.sh/v1
 kind: NodePool
 metadata:
   name: node-spot
 spec:
   disruption:
-    consolidationPolicy: WhenUnderutilized
-    expireAfter: 168h0m0s
+    consolidationPolicy: WhenEmptyOrUnderutilized
+    consolidateAfter: 1m
   limits:
     cpu: 1k
     memory: 500Gi
@@ -64,8 +67,11 @@ spec:
       labels:
         intent: apps
     spec:
+      expireAfter: 168h0m0s
       nodeClassRef:
+        group: karpenter.k8s.aws
         name: default
+        kind: EC2NodeClass
       requirements:
       - key: capacity-spread
         operator: In

--- a/blueprints/overprovision/README.md
+++ b/blueprints/overprovision/README.md
@@ -81,8 +81,8 @@ After waiting for around two minutes, you'll see all pods running and a new mach
 ```
 > kubectl get nodeclaims                                                                                                        18s
 NAME            TYPE          ZONE         NODE                                        READY   AGE
-default-kpj7k   c6i.2xlarge   eu-west-1b   ip-10-0-73-34.eu-west-1.compute.internal    True    14m
-default-s6dbs   m5.xlarge     eu-west-1a   ip-10-0-35-186.eu-west-1.compute.internal   True    2m8s
+default-4q9dn   c6g.xlarge   on-demand   eu-west-2c   ip-10-0-127-154.eu-west-2.compute.internal   True      29m
+default-xwbvp   c7g.xlarge   spot        eu-west-2c   ip-10-0-100-21.eu-west-2.compute.internal    True      75s
 ```
 
 The new machine is simply there because some "dummy" pods were pending and they exist to reserve capacity. If you think you won't need those "dummy" pods while your workload is running, you can simply reduce the "dummy" deployment replicas to 0, and Karpenter consolidation will kick in to remove unnecessary machines.

--- a/blueprints/saving-plans/savings-plans.yaml
+++ b/blueprints/saving-plans/savings-plans.yaml
@@ -1,11 +1,11 @@
-apiVersion: karpenter.sh/v1beta1
+apiVersion: karpenter.sh/v1
 kind: NodePool
 metadata:
   name: savings-plans
 spec:
   disruption:
-    consolidationPolicy: WhenUnderutilized
-    expireAfter: 168h0m0s
+    consolidationPolicy: WhenEmptyOrUnderutilized
+    consolidateAfter: 1m
   limits:
     cpu: "20" # For example: Limit to launch up to 5 c4.xlarge instances
   template:
@@ -13,8 +13,11 @@ spec:
       labels:
         intent: apps
     spec:
+      expireAfter: 168h0m0s
       nodeClassRef:
+        group: karpenter.k8s.aws
         name: default
+        kind: EC2NodeClass
       requirements:
       - key: karpenter.k8s.aws/instance-family
         operator: In

--- a/blueprints/stateful/README.md
+++ b/blueprints/stateful/README.md
@@ -60,7 +60,7 @@ Notice that Karpenter launched a node in the AZ (using the value from `$FIRSTAZ`
 ```
 > kubectl get nodes -L karpenter.sh/capacity-type,beta.kubernetes.io/instance-type,karpenter.sh/nodepool,topology.kubernetes.io/zone -l karpenter.sh/initialized=true
 NAME                                       STATUS   ROLES    AGE     VERSION               CAPACITY-TYPE   INSTANCE-TYPE   NODEPOOL   ZONE
-ip-10-0-38-15.eu-west-1.compute.internal   Ready    <none>   2m22s   v1.28.3-eks-8ccc7ba   spot            m5.xlarge       default            eu-west-1a
+ip-10-0-52-243.eu-west-2.compute.internal    Ready    <none>   16s   v1.30.2-eks-1552ad0   spot            m7g.xlarge      default    eu-west-2a
 ```
 
 Let's read the file that the pods are writing to, like this:

--- a/blueprints/update-nodes-with-drift/README.md
+++ b/blueprints/update-nodes-with-drift/README.md
@@ -10,32 +10,7 @@ Karpenter's drift will reconcile when a node's AMI drifts from `NodePool` requir
 * A Kubernetes cluster with Karpenter installed. You can use the blueprint we've used to test this pattern at the `cluster` folder in the root of this repository.
 
 ## Deploy
-Let's start by enabling the [drift](https://karpenter.sh/docs/concepts/disruption/#drift) feature gate in Karpenter's deployment environment variable. To do so, run this command:
-
-```
-kubectl -n karpenter get deployment karpenter -o yaml | \
-  sed -e 's|Drift=false|Drift=true|' | \
-  kubectl apply -f -
-```
-
-**NOTE:** You might get this message: `Warning: resource deployments/karpenter is missing the kubectl.kubernetes.io/last-applied-configuration annotation which is required by kubectl apply`. Your change will be applied, this warning appears the first time to inform you that the resource might be managed by something else. This annotation will get added and you won't see the warning going forward.
-
-You can confirm the configuration has been updated running the following command:
-
-```
-kubectl -n karpenter get deployment karpenter -o jsonpath='{.spec.template.spec.containers[0].env}' | grep Drift
-```
-
-Now, you can confirm that the Karpenter pods have been recreated:
-
-```
-❯ kubectl get pods -n karpenter
-NAME                         READY   STATUS    RESTARTS   AGE
-karpenter-7c6f4995bf-7dg5r   1/1     Running   0          2m34s
-karpenter-7c6f4995bf-82ttb   1/1     Running   0          2m34s
-```
-
-Once drift is enabled, let's create a new `EC2NodeClass` to be more precise about the AMIs you'd like to use. For now, you'll intentionally create new nodes using a previous EKS version to simulate where you'll be after upgrading the control plane. Within the `amiSelectorTerms` you'll configure the most recent AMIs (both for `amd64` and `arm64`) from a previous version of the control plane to test the drift feature.
+Let's create a new `EC2NodeClass` to be more precise about the AMIs you'd like to use. For now, you'll intentionally create new nodes using a previous EKS version to simulate where you'll be after upgrading the control plane. Within the `amiSelectorTerms` you'll configure the most recent AMIs (both for `amd64` and `arm64`) from a previous version of the control plane to test the drift feature.
 
 ```
   amiSelectorTerms:
@@ -121,7 +96,7 @@ NAME                                        STATUS   ROLES    AGE   VERSION
 ip-10-0-102-231.eu-west-2.compute.internal   Ready    <none>   51s     v1.30.2-eks-1552ad0
 ```
 
-You can repeat this process every time you need to run a controlled upgrade of the nodes.
+You can repeat this process every time you need to run a controlled upgrade of the nodes. Also, if you'd like to control when to replace a node, you can learn more about [Disruption Budgets](//blueprints/disruption-budgets/).
 
 ## Cleanup
 To remove all objects created, simply run the following commands:

--- a/blueprints/update-nodes-with-drift/README.md
+++ b/blueprints/update-nodes-with-drift/README.md
@@ -96,7 +96,7 @@ export amd64LatestAMI=$(aws ssm get-parameter --name /aws/service/eks/optimized-
 export arm64LatestAMI=$(aws ssm get-parameter --name /aws/service/eks/optimized-ami/1.30/amazon-linux-2-arm64/recommended/image_id --region $AWS_REGION --query "Parameter.Value" --output text)
 sed -i '' "s/$amd64PrevAMI/$amd64LatestAMI/g" latest-current-ami.yaml
 sed -i '' "s/$arm64PrevAMI/$arm64LatestAMI/g" latest-current-ami.yaml
-sed -i '' "s/1.27/1.29/g" latest-current-ami.yaml
+sed -i '' "s/1.29/1.30/g" latest-current-ami.yaml
 kubectl apply -f latest-current-ami.yaml
 ```
 

--- a/blueprints/update-nodes-with-drift/latest-current-ami.yaml
+++ b/blueprints/update-nodes-with-drift/latest-current-ami.yaml
@@ -1,4 +1,4 @@
-apiVersion: karpenter.k8s.aws/v1beta1
+apiVersion: karpenter.k8s.aws/v1
 kind: EC2NodeClass
 metadata:
   name: latest-current-ami-template
@@ -15,16 +15,16 @@ spec:
   - tags:
       karpenter.sh/discovery: <<CLUSTER_NAME>>
   tags:
-    KubernetesVersion: "1.27"
+    KubernetesVersion: "1.30"
 ---
-apiVersion: karpenter.sh/v1beta1
+apiVersion: karpenter.sh/v1
 kind: NodePool
 metadata:
   name: latest-current-ami
 spec:
   disruption:
-    consolidationPolicy: WhenUnderutilized
-    expireAfter: 168h0m0s
+    consolidationPolicy: WhenEmptyOrUnderutilized
+    consolidateAfter: 1m
   limits:
     cpu: 100k
     memory: 5000Gi
@@ -33,8 +33,11 @@ spec:
       labels:
         intent: latest-current-ami
     spec:
+      expireAfter: 168h0m0s
       nodeClassRef:
-        name: latest-current-ami-template
+        group: karpenter.k8s.aws
+        kind: EC2NodeClass
+        name: latest-current-ami
       requirements:
       - key: karpenter.k8s.aws/instance-category
         operator: In

--- a/blueprints/update-nodes-with-drift/latest-current-ami.yaml
+++ b/blueprints/update-nodes-with-drift/latest-current-ami.yaml
@@ -15,7 +15,7 @@ spec:
   - tags:
       karpenter.sh/discovery: <<CLUSTER_NAME>>
   tags:
-    KubernetesVersion: "1.30"
+    KubernetesVersion: "1.29"
 ---
 apiVersion: karpenter.sh/v1
 kind: NodePool

--- a/blueprints/update-nodes-with-drift/latest-current-ami.yaml
+++ b/blueprints/update-nodes-with-drift/latest-current-ami.yaml
@@ -1,7 +1,7 @@
 apiVersion: karpenter.k8s.aws/v1
 kind: EC2NodeClass
 metadata:
-  name: latest-current-ami-template
+  name: latest-current-ami
 spec:
   amiFamily: AL2
   amiSelectorTerms:

--- a/blueprints/userdata/userdata.yaml
+++ b/blueprints/userdata/userdata.yaml
@@ -4,9 +4,8 @@ metadata:
   name: userdata-template
 spec:
   amiFamily: AL2 ## Currently, Karpenter supports amiFamily values AL2, Bottlerocket, Ubuntu, Windows2019, Windows2022 and Custom.
-  amiSelectorTerms:
-    - tags:
-        karpenter.sh/discovery: "karpenter-blueprints"
+  amiSelectorTerms: 
+  - alias: al2@latest
   role: "karpenter-karpenter-blueprints"
   securityGroupSelectorTerms:
   - tags:

--- a/blueprints/userdata/userdata.yaml
+++ b/blueprints/userdata/userdata.yaml
@@ -6,13 +6,13 @@ spec:
   amiFamily: AL2 ## Currently, Karpenter supports amiFamily values AL2, Bottlerocket, Ubuntu, Windows2019, Windows2022 and Custom.
   amiSelectorTerms: 
   - alias: al2@latest
-  role: "karpenter-karpenter-blueprints"
+  role: "<<KARPENTER_NODE_IAM_ROLE_NAME>>"
   securityGroupSelectorTerms:
   - tags:
-      karpenter.sh/discovery: "karpenter-blueprints"
+      karpenter.sh/discovery: "<<CLUSTER_NAME>>"
   subnetSelectorTerms:
   - tags:
-      karpenter.sh/discovery: "karpenter-blueprints"
+      karpenter.sh/discovery: "<<CLUSTER_NAME>>"
   userData:  |
     MIME-Version: 1.0
     Content-Type: multipart/mixed; boundary="BOUNDARY"

--- a/blueprints/userdata/userdata.yaml
+++ b/blueprints/userdata/userdata.yaml
@@ -3,9 +3,8 @@ kind: EC2NodeClass
 metadata:
   name: userdata-template
 spec:
-  amiFamily: AL2 ## Currently, Karpenter supports amiFamily values AL2, Bottlerocket, Ubuntu, Windows2019, Windows2022 and Custom.
-  amiSelectorTerms: 
-  - alias: al2@latest
+  amiSelectorTerms:
+    - alias: al2023@latest # Amazon Linux 2023
   role: "<<KARPENTER_NODE_IAM_ROLE_NAME>>"
   securityGroupSelectorTerms:
   - tags:
@@ -13,7 +12,7 @@ spec:
   subnetSelectorTerms:
   - tags:
       karpenter.sh/discovery: "<<CLUSTER_NAME>>"
-  userData:  |
+  userData: |
     MIME-Version: 1.0
     Content-Type: multipart/mixed; boundary="BOUNDARY"
 
@@ -21,19 +20,7 @@ spec:
     Content-Type: text/x-shellscript; charset="us-ascii"
 
     #!/bin/bash
-
-    set -e
-
-    # Add additional KUBELET_EXTRA_ARGS to the service
-    # Requires Kubernetes 1.27 (alpha feature)
-    cat << EOF > /etc/systemd/system/kubelet.service.d/90-kubelet-extra-args.conf
-    [Service]
-    Environment="KUBELET_EXTRA_ARGS=--feature-gates=NodeLogQuery=true $KUBELET_EXTRA_ARGS"
-    EOF
-
-    # Enable log handler and log query to the kubelet configuration
-    echo "$(jq '.enableSystemLogHandler=true' /etc/kubernetes/kubelet/kubelet-config.json)" > /etc/kubernetes/kubelet/kubelet-config.json
-    echo "$(jq '.enableSystemLogQuery=true' /etc/kubernetes/kubelet/kubelet-config.json)" > /etc/kubernetes/kubelet/kubelet-config.json
+    echo "Running a custom user data script"
 
     --BOUNDARY--
 ---

--- a/blueprints/userdata/userdata.yaml
+++ b/blueprints/userdata/userdata.yaml
@@ -1,16 +1,19 @@
-apiVersion: karpenter.k8s.aws/v1beta1
+apiVersion: karpenter.k8s.aws/v1
 kind: EC2NodeClass
 metadata:
   name: userdata-template
 spec:
   amiFamily: AL2 ## Currently, Karpenter supports amiFamily values AL2, Bottlerocket, Ubuntu, Windows2019, Windows2022 and Custom.
-  role: "<<KARPENTER_NODE_IAM_ROLE_NAME>>"
+  amiSelectorTerms:
+    - tags:
+        karpenter.sh/discovery: "karpenter-blueprints"
+  role: "karpenter-karpenter-blueprints"
   securityGroupSelectorTerms:
   - tags:
-      karpenter.sh/discovery: "<<CLUSTER_NAME>>"
+      karpenter.sh/discovery: "karpenter-blueprints"
   subnetSelectorTerms:
   - tags:
-      karpenter.sh/discovery: "<<CLUSTER_NAME>>"
+      karpenter.sh/discovery: "karpenter-blueprints"
   userData:  |
     MIME-Version: 1.0
     Content-Type: multipart/mixed; boundary="BOUNDARY"
@@ -35,19 +38,22 @@ spec:
 
     --BOUNDARY--
 ---
-apiVersion: karpenter.sh/v1beta1
+apiVersion: karpenter.sh/v1
 kind: NodePool
 metadata:
   name: userdata
 spec:
   disruption:
-    consolidationPolicy: WhenUnderutilized   
+    consolidationPolicy: WhenEmptyOrUnderutilized
+    consolidateAfter: 1m
   template:     
     metadata:
       labels:
         intent: userdata
     spec:
       nodeClassRef:
+        group: karpenter.k8s.aws
+        kind: EC2NodeClass
         name: userdata-template
       requirements:
       - key: karpenter.k8s.aws/instance-hypervisor

--- a/cluster/terraform/main.tf
+++ b/cluster/terraform/main.tf
@@ -67,7 +67,7 @@ locals {
 ################################################################################
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "20.8.3"
+  version = "20.23.0"
 
   cluster_name                   = local.name
   cluster_version                = local.cluster_version
@@ -158,7 +158,7 @@ module "eks_blueprints_addons" {
   enable_karpenter = true
 
   karpenter = {
-    chart_version       = "0.37.0"
+    chart_version       = "1.0.0"
     repository_username = data.aws_ecrpublic_authorization_token.token.user_name
     repository_password = data.aws_ecrpublic_authorization_token.token.password
   }
@@ -173,7 +173,7 @@ module "eks_blueprints_addons" {
 
 module "ebs_csi_driver_irsa" {
   source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
-  version = "5.37.1"
+  version = "5.44.0"
 
   role_name_prefix = "${module.eks.cluster_name}-ebs-csi-driver-"
 
@@ -210,7 +210,7 @@ module "aws-auth" {
 
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
-  version = "5.6.0"
+  version = "5.12.1"
 
   name = local.name
   cidr = local.vpc_cidr

--- a/cluster/terraform/main.tf
+++ b/cluster/terraform/main.tf
@@ -158,7 +158,7 @@ module "eks_blueprints_addons" {
   enable_karpenter = true
 
   karpenter = {
-    chart_version       = "1.0.0"
+    chart_version       = "1.0.1"
     repository_username = data.aws_ecrpublic_authorization_token.token.user_name
     repository_password = data.aws_ecrpublic_authorization_token.token.password
   }


### PR DESCRIPTION
Update Karpenter Blueprints to Align with v1 API

This MR updates the Karpenter blueprints to fully align with the new v1 API following the Karpenter v1 release. It includes necessary adjustments to the manifests, configuration files.

Ref:
https://github.com/aws/karpenter-provider-aws/releases/tag/v1.0.0