### PR TITLE
Add an example for different budget for different disruption reasons

### DIFF
--- a/blueprints/disruption-budgets/README.md
+++ b/blueprints/disruption-budgets/README.md
@@ -146,6 +146,23 @@ spec:
       - "Underutilized"
 ```
 
+#### Only Empty Nodes
+This example sets a budget that applies only to nodes classified as Empty. During times when nodes are identified as Empty, Karpenter will only disrupt up to 10% of those nodes.
+
+```
+apiVersion: karpenter.sh/v1
+kind: NodePool
+metadata:
+  name: example-empty
+spec:
+  disruption:
+    consolidationPolicy: WhenEmptyOrUnderutilized
+    budgets:
+    - nodes: "10%"
+      reasons:
+      - "Empty"
+```
+
 #### Different Budgets for Different Reasons
 This example sets a different budget for different disruption reasons. This is useful when you want to keep minimum disruption when handling drifts while allowing more relax budget for consolidating `Empty` or `Underutilized` nodes.
 
@@ -181,9 +198,6 @@ spec:
       - "Empty"
       - "Underutilized"
 ```
-
-#### Only Empty Nodes
-This example sets a budget that applies only to nodes classified as Empty. During times when nodes are identified as Empty, Karpenter will only disrupt up to 10% of those nodes.
 
 ## Requirements
 

--- a/blueprints/disruption-budgets/README.md
+++ b/blueprints/disruption-budgets/README.md
@@ -146,22 +146,44 @@ spec:
       - "Underutilized"
 ```
 
-#### Only Empty Nodes
-This example sets a budget that applies only to nodes classified as Empty. During times when nodes are identified as Empty, Karpenter will only disrupt up to 10% of those nodes.
+#### Different Budgets for Different Reasons
+This example sets a different budget for different disruption reasons. This is useful when you want to keep minimum disruption when handling drifts while allowing more relax budget for consolidating `Empty` or `Underutilized` nodes.
+
+By this example, in the drift situation such as AMI update, Karpenter will only disrupt up to 1 node in the last minute of every 15 minutes. keeping minimum budget for drifts.
+While in the `Empty` or `Underutilized` situation, Karpenter will disrupt up to 3 nodes every 10 minutes allowing multi-nodes consolidations to happen more frequently, making the cluster more efficient.
+
 
 ```
 apiVersion: karpenter.sh/v1
 kind: NodePool
 metadata:
-  name: example-empty
+  name: example-different-budgets-reasons
 spec:
   disruption:
     consolidationPolicy: WhenEmptyOrUnderutilized
     budgets:
-    - nodes: "10%"
+    - nodes: "1"
+      reasons:
+      - "Drifted"
+    - nodes: "0"
+      schedule: "*/15 * * * *"
+      duration: 14m0s
+      reasons:
+      - "Drifted"
+    - nodes: "3"
       reasons:
       - "Empty"
+      - "Underutilized"
+    - nodes: "0"
+      schedule: "*/10 * * * *"
+      duration: 9m0s
+      reasons:
+      - "Empty"
+      - "Underutilized"
 ```
+
+#### Only Empty Nodes
+This example sets a budget that applies only to nodes classified as Empty. During times when nodes are identified as Empty, Karpenter will only disrupt up to 10% of those nodes.
 
 ## Requirements
 


### PR DESCRIPTION
*Issue #, if available:*
- 
*Description of changes:*
- Adding an example of different disruption budget for different disruption reasons.

I came across this after upgrading in v1 and it's quite useful as we needed to keep the disruption quite strict to limit blast radius of situation like AMI update/EKS upgrade, and we noticed that it affected the consolidation activity. 

with this now we are allowed to consolidate more efficiently while keeping the strict policy for update.

Let me know if it makes sense or if it's not that useful feel free to close it.

Thank you

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
