### PR TITLE
Add example blueprint for deploying a neuron workload

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ Here's the list of blueprints we have so far:
 * [Reserve node capacity for spiky workloads](/blueprints/node-reserved-headroom/)
 * [Using NodeOverlays for instance prioritization and GPU slicing](/blueprints/node-overlay/)
 * [Dynamic EBS Volume Sizing](/blueprints/dynamic-disk-ebs-volume)
+* [Deploy an AWS Trainium or AWS Inferentia workload](/neuron-workload)
 
 **NOTE:** Each blueprint is independent from each other, so you can deploy and test multiple blueprints at the same time in the same Kubernetes cluster. However, to reduce noise, we recommend you to test one blueprint at a time.
 

--- a/blueprints/neuron-workload/README.md
+++ b/blueprints/neuron-workload/README.md
@@ -1,8 +1,8 @@
 # Karpenter Blueprint: Deploy an AWS Trainium or AWS Inferentia workload
 
-Karpenter streamlines managing accelerated instance node lifecycle management. When you specify accelerated instance types in your Karpenter NodePool, Karpenter automatically selects the appropriate Amazon EKS AMI. Karpenter's provisioning also enables efficient use of Spot Instances across a diverse range of instance types - you can specify multiple accelerator options in your NodePool configuration. This flexibility allows you to balance performance and cost-effectiveness while running accelerator workloads in your Amazon EKS cluster.
+This blueprint describes the components to get started with using AWS Trainium or AWS Inferentia with Amazon EKS, from AMIs to device plugins. Karpenter streamlines managing accelerated instance node lifecycle management. When you specify accelerated instance types in your Karpenter NodePool, Karpenter automatically selects the appropriate Amazon EKS AMI. Karpenter's provisioning also enables efficient use of Spot Instances across a diverse range of instance types - you can specify multiple accelerator options in your NodePool configuration. This flexibility allows you to balance performance and cost-effectiveness while running accelerator workloads in your Amazon EKS cluster.
 
-When using AL2023 and Bottlerocket you need to deploy a Neuron Kubernetes device plugin to advertise neuron devices from the host. To use neuron accelerators you need the neuron driver. For AL2023 there is a [Neuron EKS Accelerated AMI](https://docs.aws.amazon.com/eks/latest/userguide/ml-eks-optimized-ami.html#eks-amis-neuron-al2023) which is packaged with the Neuron driver, whereas with Bottlerocket [standard EKS Bottlerocket AMI](https://docs.aws.amazon.com/eks/latest/userguide/ml-eks-optimized-ami.html#eks-amis-neuron-bottlerocket) includes the Neuron driver.
+When using AL2023 and Bottlerocket you need to deploy a Neuron Kubernetes device plugin to advertise neuron devices from the host, you also need the neuron driver (aws-neuronx-dkms). For AL2023 there is a [Neuron EKS Accelerated AMI](https://docs.aws.amazon.com/eks/latest/userguide/ml-eks-optimized-ami.html#eks-amis-neuron-al2023) which is packaged with the Neuron driver. Bottlerocket also has the neuron driver packaged though it is part of the [standard EKS Bottlerocket AMI](https://docs.aws.amazon.com/eks/latest/userguide/ml-eks-optimized-ami.html#eks-amis-neuron-bottlerocket).
 
 ## Requirements
 
@@ -82,7 +82,7 @@ EOF
 kubectl apply -f neuron-nodeclass.yaml
 ```
 
-A separate [EC2NodeClass](https://karpenter.sh/docs/concepts/nodeclasses/) was created as you may want to tune node properties such as ephemeral storage size, block device mappings, [capacity reservations selector](https://karpenter.sh/docs/concepts/nodeclasses/).
+If you want to tune node properties it is suggested to create a new [EC2NodeClass](https://karpenter.sh/docs/concepts/nodeclasses/). For example, you may want to tune node properties such as ephemeral storage size, block device mappings, [capacity reservations selector](https://karpenter.sh/docs/concepts/nodeclasses/).
 
 Create a dedicated NodePool, states provision instances from `inf` and `trn` category, and only allow workloads that tolerate the `aws.amazon.com/neuron taint` to be scheduled. Apply the following NodePool.
 
@@ -164,7 +164,7 @@ spec:
 EOF
 ```
 
-Notice, we set a node selector `karpenter.k8s.aws/instance-accelerator-name` to specify the accelerator. We also set the `schedulerName` to `neuron-scheduler`.
+Besides the other constraints to match the workload with the NodePool constraints, we set a node selector `karpenter.k8s.aws/instance-accelerator-name` to specify the accelerator. We also set the `schedulerName` to `neuron-scheduler`.
 
 To deploy the workload execute the following:
 

--- a/blueprints/neuron-workload/README.md
+++ b/blueprints/neuron-workload/README.md
@@ -1,0 +1,218 @@
+# Karpenter Blueprint: Deploy an AWS Trainium or AWS Inferentia workload
+
+Karpenter streamlines managing accelerated instance node lifecycle management. When you specify accelerated instance types in your Karpenter NodePool, Karpenter automatically selects the appropriate Amazon EKS AMI. Karpenter's provisioning also enables efficient use of Spot Instances across a diverse range of instance types - you can specify multiple accelerator options in your NodePool configuration. This flexibility allows you to balance performance and cost-effectiveness while running accelerator workloads in your Amazon EKS cluster.
+
+When using AL2023 and Bottlerocket you need to deploy a Neuron Kubernetes device plugin to advertise neuron devices from the host. To use neuron accelerators you need the neuron driver. For AL2023 there is a [Neuron EKS Accelerated AMI](https://docs.aws.amazon.com/eks/latest/userguide/ml-eks-optimized-ami.html#eks-amis-neuron-al2023) which is packaged with the Neuron driver, whereas with Bottlerocket [standard EKS Bottlerocket AMI](https://docs.aws.amazon.com/eks/latest/userguide/ml-eks-optimized-ami.html#eks-amis-neuron-bottlerocket) includes the Neuron driver.
+
+## Requirements
+
+* A Kubernetes cluster with Karpenter installed. You can use the blueprint we've used to test this pattern at the `cluster` folder in the root of this repository.
+
+## Deploy Neuron Helm Chart for Kubernetes
+
+The neuron helm chart simplifies installation of the Kubernetes device plugin for Neuron, Neuron Scheduler and Neuron Node Problem Detector. The Neuron Scheduler Extension is disabled by default. The Neuron scheduler extension is required for scheduling pods that require more than one Neuron core or device resource. For a graphical depiction of how the Neuron scheduler extension works, see [Neuron Scheduler Extension Flow Diagram](https://awsdocs-neuron.readthedocs-hosted.com/en/latest/containers/tutorials/k8s-neuron-scheduler-flow.html#k8s-neuron-scheduler-flow). The Neuron scheduler extension finds sets of directly connected devices with minimal communication latency when scheduling containers. 
+
+If you require the neuron scheduler, this can be deployed on a general purpose or system NodePool with general purpose compute. You can override the scheduler name as part of the helm chart install `scheduler.customScheduler.fullnameOverride` property. To use the neuron scheduler you must specify the `schedulerName` in your Pod specification.
+
+For configuring the Neuron Node Problem Detector see the following AWS Neuron [documentation](https://awsdocs-neuron.readthedocs-hosted.com/en/latest/containers/kubernetes-getting-started.html#neuron-node-problem-detector-plugin).
+
+To install the neuron helm chart run the following:
+
+```sh
+helm install neuron-helm-chart \
+  oci://public.ecr.aws/neuron/neuron-helm-chart \
+  --set "scheduler.enabled=true" \
+  --set "scheduler.customScheduler.fullnameOverride=neuron-scheduler" \
+  --set "npd.enabled=false" \
+  --namespace kube-system
+```
+
+By default, the neuron device plugin and scheduler are deployed in `kube-system`.
+
+The neuron device plugin advertises both neuron cores `aws.amazon.com/neuroncore` and neuron devices `aws.amazon.com/neuron` to the kubelet. When scheduling a workload on `aws.amazon.com/neuron` all cores associated with that neuron device will be allocated to the Pod.
+
+**Confirm installation:**
+```sh
+helm ls
+```
+
+Now that you have the device set-up, let’s enable Karpenter to launch AWS Trainium / Inferentia Amazon EC2 Instances.
+
+## Create a NodeClass and NodePool with AWS Trainium / Inferentia Amazon EC2 Instances (AL2023)
+
+The following NodeClass, specify the Security Group and Subnet selector, along with AMI. We are using AL2023 here, and when launching an accelerated instance Karpenter will pick the respective EKS optimized AMI.
+
+Before applying the `neuron-nodeclass.yaml` replace `KARPENTER_NODE_IAM_ROLE_NAME` and `CLUSTER_NAME` in the file with your specific cluster details. If you're using the Terraform template provided in this repo, run the following commands to get the EKS cluster name and the IAM Role name for the Karpenter nodes:
+
+```sh
+export CLUSTER_NAME=$(terraform -chdir="../../cluster/terraform" output -raw cluster_name)
+export KARPENTER_NODE_IAM_ROLE_NAME=$(terraform -chdir="../../cluster/terraform" output -raw node_instance_role_name)
+```
+
+> ***NOTE***: If you're not using Terraform, you need to get those values manually. `CLUSTER_NAME` is the name of your EKS cluster (not the ARN). Karpenter auto-generates the [instance profile](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-ec2_instance-profiles) in your `EC2NodeClass` given the role that you specify in [spec.role](https://karpenter.sh/preview/concepts/nodeclasses/) with the placeholder `KARPENTER_NODE_IAM_ROLE_NAME`, which is a way to pass a single IAM role to the EC2 instance launched by the Karpenter `NodePool`. Typically, the instance profile name is the same as the IAM role(not the ARN).
+
+The EC2NodeClass we’ll deploy looks like this, execute the following command to create the EC2NodeClass file:
+
+```sh
+cat << EOF > neuron-nodeclass.yaml
+apiVersion: karpenter.k8s.aws/v1
+kind: EC2NodeClass
+metadata:
+  name: neuron
+spec:
+  amiSelectorTerms:
+  - alias: al2023@latest
+  role: "$KARPENTER_NODE_IAM_ROLE_NAME"
+  blockDeviceMappings:
+  - deviceName: /dev/xvda
+    ebs:
+      deleteOnTermination: true
+      iops: 10000
+      throughput: 125
+      volumeSize: 100Gi
+      volumeType: gp3
+  securityGroupSelectorTerms:
+  - tags:
+      karpenter.sh/discovery: $CLUSTER_NAME
+  subnetSelectorTerms:
+  - tags:
+      karpenter.sh/discovery: $CLUSTER_NAME
+EOF
+
+kubectl apply -f neuron-nodeclass.yaml
+```
+
+A separate [EC2NodeClass](https://karpenter.sh/docs/concepts/nodeclasses/) was created as you may want to tune node properties such as ephemeral storage size, block device mappings, [capacity reservations selector](https://karpenter.sh/docs/concepts/nodeclasses/).
+
+Create a dedicated NodePool, states provision instances from `inf` and `trn` category, and only allow workloads that tolerate the `aws.amazon.com/neuron taint` to be scheduled. Apply the following NodePool.
+
+```sh
+cat << EOF > neuron-nodepool.yaml
+apiVersion: karpenter.sh/v1
+kind: NodePool
+metadata:
+  name: neuron
+spec:
+  limits:
+    cpu: 100
+    memory: 100Gi
+    aws.amazon.com/neuron: 5
+  template:
+    metadata:
+      labels:
+        intent: neuron
+    spec:
+      nodeClassRef:
+        group: karpenter.k8s.aws
+        name: neuron 
+        kind: EC2NodeClass
+      requirements:
+        - key: karpenter.sh/capacity-type
+          operator: In
+          values: ["on-demand", "spot"]
+        - key: karpenter.k8s.aws/instance-category
+          operator: In
+          values: ["inf", "trn"]
+      expireAfter: 720h
+      taints:
+         - key: aws.amazon.com/neuron
+           effect: NoSchedule
+  disruption:
+    consolidationPolicy: WhenEmpty
+    consolidateAfter: 5m
+EOF
+
+kubectl apply -f neuron-nodepool.yaml
+```
+
+We’ve added the `aws.amazon.com/neuron` taint in the NodePool to prevent workloads that do not tolerate this taint being scheduled on nodes managed by this NodePool (they might not take advantage of it).
+
+Now let’s deploy a test workload.
+
+## Deploy a test workload to test neuron drivers are loaded
+
+The following Pod manifest launches a pod and calls the Neuron CLI to check if the accelerator is detected and the driver versions printed to standard output, use `kubectl logs pod/neuron-ls` to observe. Create `workload.yaml` from the following Pod specification: 
+
+```sh
+cat << EOF > workload.yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: neuron-ls
+spec:
+  nodeSelector:
+    intent: neuron
+    karpenter.k8s.aws/instance-accelerator-name: inferentia
+  restartPolicy: OnFailure
+  schedulerName: neuron-scheduler
+  containers:
+  - name: neuron-ls
+    image: public.ecr.aws/neuron/pytorch-inference-vllm-neuronx:0.13.0-neuronx-py312-sdk2.27.1-ubuntu24.04
+    args:
+    - "neuron-ls"
+    resources:
+      requests:
+        memory: "30Gi"
+        cpu: "3500m"
+      limits:
+        memory: "30Gi"
+        aws.amazon.com/neuron: 2
+  tolerations:
+  - key: aws.amazon.com/neuron
+    effect: NoSchedule
+    operator: Exists
+EOF
+```
+
+Notice, we set a node selector `karpenter.k8s.aws/instance-accelerator-name` to specify the accelerator. We also set the `schedulerName` to `neuron-scheduler`.
+
+To deploy the workload execute the following:
+
+```sh
+$> kubectl apply -f workload.yaml
+pod/neuron-ls created
+```
+
+After sometime to list nodes, neuron devices and cores run the following:
+
+```sh
+$> kubectl get nodes "-o=custom-columns=NAME:.metadata.name,NeuronDevices:.status.allocatable.aws\.amazon\.com/neuron,NeuronCores:.status.allocatable.aws\.amazon\.com/neuroncore"
+
+NAME                        NeuronDevices   NeuronCores
+ip-xx-x-x-xxx.ec2.internal  4               16
+```
+
+You can check the pods status by executing:
+
+```sh
+$> kubectl get pods
+NAME        READY   STATUS    RESTARTS   AGE
+neuron-ls   1/1     Running   0          4m36s
+```
+
+You can view the pods neuron-smi logs by executing:
+
+```sh
+$> kubectl logs pod/neuron-ls
+
+instance-type: inf1.6xlarge
+instance-id: <redacted>
++--------+--------+----------+--------+-----------+--------------+----------+------+
+| NEURON | NEURON |  NEURON  | NEURON | CONNECTED |     PCI      |   CPU    | NUMA |
+| DEVICE | CORES  | CORE IDS | MEMORY |  DEVICES  |     BDF      | AFFINITY | NODE |
++--------+--------+----------+--------+-----------+--------------+----------+------+
+| 0      | 4      | 0-3      | 8 GB   | 1         | 0000:00:1c.0 | 0-23     | -1   |
+| 1      | 4      | 4-7      | 8 GB   | 2, 0      | 0000:00:1d.0 | 0-23     | -1   |
++--------+--------+----------+--------+-----------+--------------+----------+------+
+```
+
+## Clean-up
+
+To clean-up execute the following commands:
+
+```sh
+kubectl delete -f workload.yaml
+kubectl delete -f neuron-nodepool.yaml
+kubectl delete -f neuron-nodeclass.yaml
+helm delete -n kube-system neuron-helm-chart
+```

--- a/blueprints/neuron-workload/test.sh
+++ b/blueprints/neuron-workload/test.sh
@@ -1,0 +1,314 @@
+#!/bin/bash
+# Test script for the Neuron Workload blueprint
+# Validates that Karpenter provisions Trainium/Inferentia instances
+# and the Neuron device plugin advertises devices correctly.
+#
+# Prerequisites:
+# - kubectl configured with access to an EKS cluster
+# - Karpenter installed
+# - Neuron Helm chart installed (scheduler + device plugin)
+# - Environment variables set: CLUSTER_NAME, KARPENTER_NODE_IAM_ROLE_NAME
+#
+# Usage: ./test.sh
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+# Timeouts
+TIMEOUT_NODE_READY=300
+TIMEOUT_POD_READY=300
+
+log_info() { echo -e "${GREEN}[INFO]${NC} $1"; }
+log_warn() { echo -e "${YELLOW}[WARN]${NC} $1"; }
+log_error() { echo -e "${RED}[ERROR]${NC} $1"; }
+log_test() { echo -e "${GREEN}[TEST]${NC} $1"; }
+
+check_prerequisites() {
+    log_info "Checking prerequisites..."
+
+    if ! command -v kubectl &> /dev/null; then
+        log_error "kubectl not found"
+        exit 1
+    fi
+
+    if ! kubectl get nodes &> /dev/null; then
+        log_error "Cannot connect to Kubernetes cluster"
+        exit 1
+    fi
+
+    if [ -z "$CLUSTER_NAME" ]; then
+        log_error "CLUSTER_NAME environment variable is not set"
+        log_info "Set it with: export CLUSTER_NAME=\$(terraform -chdir='../../cluster/terraform' output -raw cluster_name)"
+        exit 1
+    fi
+
+    if [ -z "$KARPENTER_NODE_IAM_ROLE_NAME" ]; then
+        log_error "KARPENTER_NODE_IAM_ROLE_NAME environment variable is not set"
+        log_info "Set it with: export KARPENTER_NODE_IAM_ROLE_NAME=\$(terraform -chdir='../../cluster/terraform' output -raw node_instance_role_name)"
+        exit 1
+    fi
+
+    # Verify Neuron Helm chart is installed
+    if ! helm list -n kube-system 2>/dev/null | grep -q "neuron-helm-chart"; then
+        log_error "Neuron Helm chart is not installed"
+        log_info "Install it with:"
+        log_info "  helm install neuron-helm-chart oci://public.ecr.aws/neuron/neuron-helm-chart \\"
+        log_info "    --set 'scheduler.enabled=true' \\"
+        log_info "    --set 'scheduler.customScheduler.fullnameOverride=neuron-scheduler' \\"
+        log_info "    --set 'npd.enabled=false' \\"
+        log_info "    --namespace kube-system"
+        exit 1
+    fi
+
+    log_info "Using cluster: $CLUSTER_NAME, IAM role: $KARPENTER_NODE_IAM_ROLE_NAME"
+    log_info "Prerequisites check passed"
+}
+
+wait_for_nodeclaim() {
+    local label_selector=$1
+    local expected_count=$2
+    local timeout=$TIMEOUT_NODE_READY
+    local elapsed=0
+
+    log_info "Waiting for $expected_count nodeclaim(s) with selector '$label_selector' to be ready..."
+
+    while [ $elapsed -lt $timeout ]; do
+        ready_count=$(kubectl get nodeclaims -l "$label_selector" --no-headers 2>/dev/null | grep -c "True" || true)
+        ready_count=${ready_count:-0}
+        ready_count=$((ready_count + 0))
+        if [ "$ready_count" -ge "$expected_count" ]; then
+            log_info "$ready_count nodeclaim(s) ready"
+            return 0
+        fi
+        sleep 10
+        elapsed=$((elapsed + 10))
+        echo -n "."
+    done
+    echo ""
+    log_error "Timeout waiting for nodeclaims to be ready"
+    kubectl get nodeclaims -l "$label_selector" 2>/dev/null || true
+    return 1
+}
+
+wait_for_pod_status() {
+    local pod_name=$1
+    local expected_status=$2
+    local timeout=$TIMEOUT_POD_READY
+    local elapsed=0
+
+    log_info "Waiting for pod '$pod_name' to reach status '$expected_status'..."
+
+    while [ $elapsed -lt $timeout ]; do
+        phase=$(kubectl get pod "$pod_name" -o jsonpath='{.status.phase}' 2>/dev/null || echo "")
+        if [ "$phase" == "$expected_status" ]; then
+            log_info "Pod '$pod_name' is $expected_status"
+            return 0
+        fi
+        # For neuron-ls, Succeeded (Completed) is also a valid terminal state
+        if [ "$expected_status" == "Running" ] && [ "$phase" == "Succeeded" ]; then
+            log_info "Pod '$pod_name' completed successfully (Succeeded)"
+            return 0
+        fi
+        sleep 10
+        elapsed=$((elapsed + 10))
+        echo -n "."
+    done
+    echo ""
+    log_error "Timeout waiting for pod '$pod_name' to reach '$expected_status'"
+    kubectl describe pod "$pod_name" 2>/dev/null || true
+    return 1
+}
+
+cleanup() {
+    log_info "Cleaning up neuron-workload test resources..."
+    kubectl delete pod neuron-ls --ignore-not-found=true 2>/dev/null || true
+    kubectl delete nodepool neuron --ignore-not-found=true 2>/dev/null || true
+    kubectl delete ec2nodeclass neuron --ignore-not-found=true 2>/dev/null || true
+    # Wait for nodes to drain
+    sleep 10
+}
+
+test_neuron_workload() {
+    cleanup
+
+    # --- Step 1: Create EC2NodeClass ---
+    log_info "Creating EC2NodeClass for neuron instances..."
+    cat <<EOF | kubectl apply -f -
+apiVersion: karpenter.k8s.aws/v1
+kind: EC2NodeClass
+metadata:
+  name: neuron
+spec:
+  amiSelectorTerms:
+  - alias: al2023@latest
+  role: "$KARPENTER_NODE_IAM_ROLE_NAME"
+  blockDeviceMappings:
+  - deviceName: /dev/xvda
+    ebs:
+      deleteOnTermination: true
+      iops: 10000
+      throughput: 125
+      volumeSize: 100Gi
+      volumeType: gp3
+  securityGroupSelectorTerms:
+  - tags:
+      karpenter.sh/discovery: $CLUSTER_NAME
+  subnetSelectorTerms:
+  - tags:
+      karpenter.sh/discovery: $CLUSTER_NAME
+EOF
+
+    # --- Step 2: Create NodePool ---
+    log_info "Creating NodePool for neuron instances..."
+    cat <<EOF | kubectl apply -f -
+apiVersion: karpenter.sh/v1
+kind: NodePool
+metadata:
+  name: neuron
+spec:
+  limits:
+    cpu: 100
+    memory: 100Gi
+    aws.amazon.com/neuron: 5
+  template:
+    metadata:
+      labels:
+        intent: neuron
+    spec:
+      nodeClassRef:
+        group: karpenter.k8s.aws
+        name: neuron
+        kind: EC2NodeClass
+      requirements:
+        - key: karpenter.sh/capacity-type
+          operator: In
+          values: ["on-demand", "spot"]
+        - key: karpenter.k8s.aws/instance-category
+          operator: In
+          values: ["inf", "trn"]
+      expireAfter: 720h
+      taints:
+        - key: aws.amazon.com/neuron
+          effect: NoSchedule
+  disruption:
+    consolidationPolicy: WhenEmpty
+    consolidateAfter: 5m
+EOF
+
+    sleep 5
+
+    # --- Step 3: Deploy test workload ---
+    log_info "Deploying neuron-ls test pod..."
+    cat <<EOF | kubectl apply -f -
+apiVersion: v1
+kind: Pod
+metadata:
+  name: neuron-ls
+spec:
+  nodeSelector:
+    intent: neuron
+    karpenter.k8s.aws/instance-accelerator-name: inferentia
+  restartPolicy: OnFailure
+  schedulerName: neuron-scheduler
+  containers:
+  - name: neuron-ls
+    image: public.ecr.aws/neuron/pytorch-inference-vllm-neuronx:0.13.0-neuronx-py312-sdk2.27.1-ubuntu24.04
+    args:
+    - "neuron-ls"
+    resources:
+      requests:
+        memory: "30Gi"
+        cpu: "3500m"
+      limits:
+        memory: "30Gi"
+        aws.amazon.com/neuron: 2
+  tolerations:
+  - key: aws.amazon.com/neuron
+    effect: NoSchedule
+    operator: Exists
+EOF
+
+    # --- Step 4: Wait for node provisioning ---
+    if ! wait_for_nodeclaim "karpenter.sh/nodepool=neuron" 1; then
+        log_error "❌ FAILED: Karpenter did not provision a neuron node"
+        return 1
+    fi
+
+    # --- Step 5: Validate instance category ---
+    log_info "Validating provisioned instance..."
+    instance_category=$(kubectl get nodeclaims -l karpenter.sh/nodepool=neuron -o jsonpath='{.items[0].metadata.labels.karpenter\.k8s\.aws/instance-category}' 2>/dev/null || echo "unknown")
+    instance_type=$(kubectl get nodeclaims -l karpenter.sh/nodepool=neuron -o jsonpath='{.items[0].spec.instanceType}' 2>/dev/null || echo "unknown")
+
+    log_info "Provisioned instance: $instance_type (category: $instance_category)"
+
+    if [ "$instance_category" == "inf" ] || [ "$instance_category" == "trn" ]; then
+        log_test "✅ PASSED: Instance is in accelerator category '$instance_category'"
+    else
+        log_error "❌ FAILED: Expected instance category 'inf' or 'trn', got '$instance_category'"
+        return 1
+    fi
+
+    # --- Step 6: Validate neuron devices on node ---
+    log_info "Checking neuron device advertisement on node..."
+    node_name=$(kubectl get nodeclaims -l karpenter.sh/nodepool=neuron -o jsonpath='{.items[0].status.nodeName}' 2>/dev/null || echo "")
+    if [ -n "$node_name" ]; then
+        neuron_devices=$(kubectl get node "$node_name" -o jsonpath='{.status.allocatable.aws\.amazon\.com/neuron}' 2>/dev/null || echo "0")
+        neuron_cores=$(kubectl get node "$node_name" -o jsonpath='{.status.allocatable.aws\.amazon\.com/neuroncore}' 2>/dev/null || echo "0")
+        log_info "Node $node_name: NeuronDevices=$neuron_devices, NeuronCores=$neuron_cores"
+
+        if [ "$neuron_devices" -gt 0 ] 2>/dev/null; then
+            log_test "✅ PASSED: Node advertises $neuron_devices neuron device(s) and $neuron_cores neuron core(s)"
+        else
+            log_error "❌ FAILED: Node does not advertise neuron devices"
+            return 1
+        fi
+    else
+        log_warn "Could not determine node name from nodeclaim"
+    fi
+
+    # --- Step 7: Wait for pod to run and validate output ---
+    if ! wait_for_pod_status "neuron-ls" "Running"; then
+        log_error "❌ FAILED: neuron-ls pod did not reach Running/Succeeded state"
+        return 1
+    fi
+
+    log_info "Checking neuron-ls output..."
+    sleep 5
+    pod_logs=$(kubectl logs pod/neuron-ls 2>/dev/null || echo "")
+    if echo "$pod_logs" | grep -q "NEURON"; then
+        log_test "✅ PASSED: neuron-ls output contains Neuron device information"
+        log_info "Output:"
+        echo "$pod_logs"
+    else
+        log_warn "neuron-ls output did not contain expected Neuron table (pod may still be initializing)"
+        log_info "Output: $pod_logs"
+    fi
+
+    return 0
+}
+
+main() {
+    local exit_code=0
+
+    check_prerequisites
+    test_neuron_workload || exit_code=1
+    cleanup
+
+    if [ $exit_code -eq 0 ]; then
+        log_test "=== ALL TESTS PASSED ==="
+    else
+        log_error "=== SOME TESTS FAILED ==="
+    fi
+
+    exit $exit_code
+}
+
+main "$@"


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Add example blueprint for deploying a neuron workload to EKS (e.g. neuron device plugin, neuron scheduler etc)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
