### PR TITLE
fix: ebs addon terraform instalation loop with pod identity

### DIFF
--- a/cluster/terraform/main.tf
+++ b/cluster/terraform/main.tf
@@ -71,9 +71,6 @@ module "eks" {
   enable_cluster_creator_admin_permissions = true
 
   addons = {
-    aws-ebs-csi-driver = {
-      most_recent = true
-    }
     coredns = {
       most_recent = true
     }
@@ -147,6 +144,13 @@ module "eks_blueprints_addons" {
 
   create_delay_dependencies = [for grp in module.eks.eks_managed_node_groups : grp.node_group_arn]
 
+  eks_addons = {
+    # Amazon EKS add-ons
+    aws-ebs-csi-driver = {
+      most_recent = true
+    }
+  }
+
   enable_aws_load_balancer_controller = true
 
   enable_aws_for_fluentbit = true
@@ -160,6 +164,8 @@ module "eks_blueprints_addons" {
   }
 
   tags = local.tags
+
+  depends_on = [module.aws_ebs_csi_pod_identity]
 }
 
 module "aws_ebs_csi_pod_identity" {


### PR DESCRIPTION
*Description of changes:*
EBS addon crashed due to lack of permissions that are assigned by the pod identity association, however, the association needed to be deployed prior. 

`https response error StatusCode: 403, RequestID: 685b505f-f18d-46c3-bdc2-97f8454370ce, api error UnauthorizedOperation: You are not authorized to perform this operation. User: arn:aws:sts::foo:bar is not authorized to perform: ec2:DescribeAvailabilityZones because no identity-based policy allows the ec2:DescribeAvailabilityZones action`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
